### PR TITLE
Use pattern matching to avoid duplicate node-info for interacting genes

### DIFF
--- a/helpers/utils.scm
+++ b/helpers/utils.scm
@@ -146,34 +146,57 @@ info
     ) 
 
         (begin
-            (let ([output (findpubmed gene-a gene-b)])
+            (let* ([output (findpubmed gene-a gene-b)]
+                  [res (flatten (map (lambda (x) 
+                                    (if (not (member (cog-name x) (atoms)))
+                                        (cog-name x)
+                                        '()
+                                    ) 
+                    )  (list gene-a gene-b))) ]
+                  [interaction (if (null? output) (EvaluationLink 
+                                        (PredicateNode "interacts_with") 
+                                        (ListLink gene-a gene-b))
+                                        (EvaluationLink
+                                            (PredicateNode "has_pubmedID")
+                                            (ListLink (EvaluationLink 
+                                                     (PredicateNode "interacts_with") 
+                                                     (ListLink gene-a gene-b))  
+                                                    output)
+                                        ))]   
+                )
                 (pairs (append (list (cons gene-a gene-b)) (pairs)))
-                (if (null? output)
-                    (ListLink 
-                        (EvaluationLink 
-                            (PredicateNode "interacts_with") 
-                            (ListLink gene-a gene-b))
-                        (node-info gene-b)
-                        (node-info gene-a)
-                    )
-                    (ListLink 
-                        (EvaluationLink
-                            (PredicateNode "has_pubmedID")
-                            (ListLink 
-                                (EvaluationLink (PredicateNode "interacts_with") (ListLink gene-a gene-b))
-                                output
+                (match res
+                    ((a b)
+                        (begin 
+                            (atoms (append (list a b) (atoms)))
+                            (ListLink
+                                interaction
+                                (node-info (GeneNode a))
+                                (node-info (GeneNode b))
                             )
                         )
-                        (node-info gene-a)
-                        (ListLink (locate-node gene-a))
-                        (node-info gene-b)
-                        (ListLink (locate-node gene-b))
-                        )
+                    )
+                    ((a)
+                        (begin 
+                            (atoms (append (list a) (atoms)))
+                            (ListLink
+                                interaction
+                            (node-info (GeneNode a))
+                        ))
+                    )
+                    (()
+                            (ListLink
+                                interaction
+                            )
                     )
                 )
+            )
         )
     
-))
+    
+    (ListLink )
+  )
+)
 
 (define (generate-ppi-result gene-a prot-a gene-b prot-b)
     (if (and (not (member (cons gene-a prot-a) (pairs)))

--- a/opencog_deps
+++ b/opencog_deps
@@ -15,6 +15,6 @@
 (use-modules (ice-9 regex))
 (use-modules (srfi srfi-98))
 
-
+(use-modules (ice-9 match))
 (use-modules (ice-9 ftw))
 (use-modules (srfi srfi-1))


### PR DESCRIPTION
I have added a scheme pattern matching (in `(ice-9 match)`) to avoid duplicate information for a gene that interacts with many other genes. This will reduce the output size significantly.