### PR TITLE
Remove duplicate edges from pathway and biogrid results

### DIFF
--- a/annotation/biogrid.scm
+++ b/annotation/biogrid.scm
@@ -29,7 +29,7 @@
 		#:export (biogrid-interaction-annotation)
 )
 (define* (biogrid-interaction-annotation gene-nodes interaction #:optional (namespace "") (parents 0) #:key (id ""))
-  (let ([result (list (ConceptNode "biogrid-interaction-annotation"))]
+  (let ([result '()]
         [go (if (string=? namespace "") (ListLink) 
                 (ListLink (ConceptNode namespace) (Number parents)))])
 	
@@ -46,7 +46,7 @@
 	) gene-nodes)
 
 	 (let (
-    	[res (ListLink result)]
+    	[res (ListLink (ConceptNode "biogrid-interaction-annotation") (ListLink result))]
   		)
     	(write-to-file res id "biogrid")
 		res

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -740,13 +740,6 @@
   )
 )
 
-(define-public (generate-ppi-result gene-a prot-a )
-        (ListLink
-                (EvaluationLink (PredicateNode "expresses") (ListLink gene-a prot-a))
-                (node-info prot-a)
-        )
-)
-
 (define-public (generate-interactors path gene var1 var2)
   (if (and (not (string=? (cog-name var1) (cog-name var2)))
           (not (or (string=? (cog-name gene) (cog-name var1))(string=? (cog-name gene) (cog-name var2))))

--- a/annotation/gene-go.scm
+++ b/annotation/gene-go.scm
@@ -28,16 +28,14 @@
     #:use-module (annotation parser)
     #:export (gene-go-annotation)
 )
+
 (define* (gene-go-annotation gene-nodes namespace #:optional (parents 0) #:key (id ""))
     (let (
-        [result (ListLink (ConceptNode "gene-go-annotation")
-    (flatten (map (lambda (gene) 
-      (find-go-term gene  (string-split namespace #\ ) parents)
-  
-    ) gene-nodes)))]
-      )
+        [result (flatten (map (lambda (gene) 
+          (find-go-term gene  (string-split namespace #\ ) parents)) gene-nodes))]
+          )
     (let (
-    	[res (ListLink result)]
+    	[res (ListLink (ConceptNode "gene-go-annotation") (ListLink result))]
   		)
     	(write-to-file res id "gene-go")
       res

--- a/annotation/gene-pathway.scm
+++ b/annotation/gene-pathway.scm
@@ -31,7 +31,7 @@
 )
 ;; (list "cellular_component molecular_function biological_process" parent)
 (define* (gene-pathway-annotation gene_nodes pathway prot small_mol #:optional (namespace "") (parents 0) #:key (id "") )
-    (let ([result (list (ConceptNode "gene-pathway-annotation"))]
+    (let ([result '()]
           [pwlst '()]
           [go (if (string=? namespace "") (ListLink) 
                 (ListLink (ConceptNode namespace) (Number parents)))])
@@ -52,7 +52,7 @@
     ) gene_nodes)
  
     (let (
-      [res (ListLink result)]
+      [res (ListLink (ConceptNode "gene-pathway-annotation") (ListLink result))]
     )
       (write-to-file res id "gene-pathway")
       res

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -71,6 +71,7 @@ atomspace."
                   (atoms '()) 
                   (genes gene-list)
                   (biogrid-genes '())
+                  (biogrid-pairs '())
                   (annotation "")
                   (prev-annotation "")
               )

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -42,6 +42,7 @@
 (define-public atoms (make-parameter '()))
 (define-public genes (make-parameter '()))
 (define-public biogrid-genes (make-parameter '()))
+(define-public biogrid-pairs (make-parameter '()))
 (define-public annotation (make-parameter ""))
 (define-public prev-annotation (make-parameter ""))
 


### PR DESCRIPTION
This PR fixes the issue of having duplicate interaction links in the scheme result and hence also in the JSON. 

I have added a `biogrid-pairs` parameter to track the edges in addition to the nodes