### PR TITLE
Remove outdated gene symbols and replace them with the current

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -819,7 +819,7 @@
 )
 
 ;;                           
-(define (find-pubmed-id gene-a gene-b)
+(define-public (find-pubmed-id gene-a gene-b)
  (let ([pub (cog-outgoing-set (cog-execute!
      (GetLink
        (VariableNode "$pub")

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -45,7 +45,7 @@ atomspace."
                            (null? (cog-node 'GeneNode gene)))
                          gene-list)))
     (match unknown
-      (() "0")
+      (() (check-outdate-genes gene-list))
       (_ 
         (let* (
           (res (flatten (map find-similar-gene unknown)))

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -52,6 +52,7 @@ atomspace."
           (suggestions (if (> (length res) 5) (map (lambda (u) (cog-name u)) (take res 5)) (map (lambda (u) (cog-name u)) res))
              )
         )
+        (map (lambda (g) (cog-delete-recursive (GeneNode g))) gene-list)
           (if (null? suggestions)
             (string-append "1:" (string-join unknown ","))
             (string-append "1:" (string-join unknown ",") "\nHere are some suggestions " (string-join suggestions ","))

--- a/annotation/pln_rule.scm
+++ b/annotation/pln_rule.scm
@@ -1,0 +1,263 @@
+(define biogrid_interaction_rule
+    (BindLink
+        (VariableList
+            (TypedVariable (Variable "$g") (Type "GeneNode"))
+            (TypedVariable (Variable "$gg") (Type "GeneNode"))
+            (TypedVariable (Variable "$ggg") (Type "GeneNode"))
+        ) 
+        (And
+            (EvaluationLink
+                (PredicateNode "has_current_symbol")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$gg")))
+            (EvaluationLink
+                (PredicateNode "interacts_with")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$ggg")
+                )
+            )
+	    )
+        (ListLink
+            (EvaluationLink
+                (PredicateNode "has_pubmedID")
+                (ListLink
+                (EvaluationLink
+                    (PredicateNode "interacts_with")
+                    (ListLink
+                        (Variable "$gg")
+                        (Variable "$ggg")
+                    )
+                )
+                (find-pubmed-id (Variable "$g") (Variable "$ggg"))
+                )
+            )
+            (DeleteLink
+                (EvaluationLink
+                  (PredicateNode "interacts_with")
+                  (ListLink
+                     (Variable "$g")
+                     (Variable "$ggg")
+                  )
+               )
+            )
+        )
+    )
+)
+(define member_rule
+    (BindLink
+        (VariableList
+            (TypedVariable (Variable "$g") (Type "GeneNode"))
+            (TypedVariable (Variable "$gg") (Type "GeneNode"))
+            (TypedVariable (Variable "$c") (Type "ConceptNode"))
+        ) 
+        (And
+            (EvaluationLink
+                (PredicateNode "has_current_symbol")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$gg")))
+            (MemberLink
+                (Variable "$g")
+                (Variable "$c"))
+	    )
+        (ListLink
+            (MemberLink
+                (Variable "$gg")
+                (Variable "$c"))
+            (DeleteLink
+                (MemberLink
+                    (Variable "$g")
+                    (Variable "$c"))
+            )
+        )
+    )
+)
+(define expresses_rule
+    (BindLink
+        (VariableList
+            (TypedVariable (Variable "$g") (Type "GeneNode"))
+            (TypedVariable (Variable "$gg") (Type "GeneNode"))
+            (TypedVariable (Variable "$m") (Type "MoleculeNode"))
+        ) 
+        (And
+            (EvaluationLink
+                (PredicateNode "has_current_symbol")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$gg")))
+            (EvaluationLink
+                (PredicateNode "expresses")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$m")))
+	    )
+        (ListLink
+            (EvaluationLink
+                (PredicateNode "expresses")
+                (ListLink
+                    (Variable "$gg")
+                    (Variable "$m")))
+            (DeleteLink
+                (EvaluationLink
+                    (PredicateNode "expresses")
+                    (ListLink
+                        (Variable "$g")
+                        (Variable "$m")))
+            )
+        )
+    )
+)
+(define location_rule
+    (BindLink
+        (VariableList
+            (TypedVariable (Variable "$g") (Type "GeneNode"))
+            (TypedVariable (Variable "$gg") (Type "GeneNode"))
+            (TypedVariable (Variable "$l") (Type "ConceptNode"))
+        ) 
+        (And
+            (EvaluationLink
+                (PredicateNode "has_current_symbol")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$gg")))
+            (EvaluationLink (stv 1 1)
+                (PredicateNode "has_location")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$l")))
+        )
+        (ListLink
+            (EvaluationLink (stv 1 1)
+                (PredicateNode "has_location")
+                (ListLink
+                (Variable "$gg")
+                (Variable "$l")
+                ))
+            (DeleteLink
+                (EvaluationLink (stv 1 1)
+                    (PredicateNode "has_location")
+                    (ListLink
+                        (Variable "$g")
+                        (Variable "$l")))
+            )
+        )
+    )
+)
+(define name_rule
+    (BindLink
+        (VariableList
+            (TypedVariable (Variable "$g") (Type "GeneNode"))
+            (TypedVariable (Variable "$gg") (Type "GeneNode"))
+            (TypedVariable (Variable "$n") (Type "ConceptNode"))
+        ) 
+        (And
+            (EvaluationLink
+                (PredicateNode "has_current_symbol")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$gg")))
+            (EvaluationLink (stv 1 1)
+                (PredicateNode "has_name")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$n")))
+        )
+        (ListLink
+            (EvaluationLink (stv 1 1)
+                (PredicateNode "has_name")
+                (ListLink
+                (Variable "$gg")
+                (Variable "$n")
+                ))
+            (DeleteLink
+                (EvaluationLink (stv 1 1)
+                    (PredicateNode "has_name")
+                    (ListLink
+                        (Variable "$g")
+                        (Variable "$n")))
+            )
+        )
+    )
+)
+(define biogird_id_rule
+    (BindLink
+        (VariableList
+            (TypedVariable (Variable "$g") (Type "GeneNode"))
+            (TypedVariable (Variable "$gg") (Type "GeneNode"))
+            (TypedVariable (Variable "$b") (Type "ConceptNode"))
+        ) 
+        (And
+            (EvaluationLink
+                (PredicateNode "has_current_symbol")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$gg")))
+            (EvaluationLink (stv 1 1)
+                (PredicateNode "has_biogridID")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$b")))
+        )
+        (ListLink        
+            (EvaluationLink (stv 1 1)
+                (PredicateNode "has_biogridID")
+                (ListLink
+                (Variable "$gg")
+                (Variable "$b")
+                ))
+            (DeleteLink
+                (EvaluationLink (stv 1 1)
+                    (PredicateNode "has_biogridID")
+                    (ListLink
+                        (Variable "$g")
+                        (Variable "$b")))
+            )
+        )
+    )
+)
+(define entrez_id_rule
+    (BindLink
+        (VariableList
+            (TypedVariable (Variable "$g") (Type "GeneNode"))
+            (TypedVariable (Variable "$gg") (Type "GeneNode"))
+            (TypedVariable (Variable "$e") (Type "ConceptNode"))
+        ) 
+        (And
+            (EvaluationLink
+                (PredicateNode "has_current_symbol")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$gg")))
+            (EvaluationLink (stv 1 1)
+                (PredicateNode "has_entrez_id")
+                (ListLink
+                    (Variable "$g")
+                    (Variable "$e")))
+        )
+        (ListLink        
+            (EvaluationLink (stv 1 1)
+                (PredicateNode "has_entrez_id")
+                (ListLink
+                (Variable "$gg")
+                (Variable "$e")
+                ))
+            (DeleteLink
+                (EvaluationLink (stv 1 1)
+                    (PredicateNode "has_entrez_id")
+                    (ListLink
+                        (Variable "$g")
+                        (Variable "$e")))
+            )
+        )
+    )
+)
+
+(cog-execute! biogrid_interaction_rule)
+(cog-execute! member_rule)
+(cog-execute! expresses_rule)
+(cog-execute! name_rule)
+(cog-execute! location_rule)
+(cog-execute! biogird_id_rule)
+(cog-execute! entrez_id_rule)

--- a/annotation/pln_rule.scm
+++ b/annotation/pln_rule.scm
@@ -35,12 +35,19 @@
             )
             (DeleteLink
                 (EvaluationLink
-                  (PredicateNode "interacts_with")
-                  (ListLink
-                     (Variable "$g")
-                     (Variable "$ggg")
-                  )
-               )
+                        (PredicateNode "interacts_with")
+                        (ListLink
+                            (Variable "$g")
+                            (Variable "$ggg")
+                        )
+                )
+                (EvaluationLink
+                        (PredicateNode "interacts_with")
+                        (ListLink
+                            (Variable "$ggg")
+                            (Variable "$g")
+                        )
+                )
             )
         )
     )

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -222,6 +222,36 @@
     )
 )
 
+(define (find-current-symbol gene-list)
+  (let ((current (map (lambda (gene)  
+    (let ((cur (cog-outgoing-set 
+      (cog-execute! (BindLink
+        (TypedVariable (Variable "$g") (Type "GeneNode"))
+        (EvaluationLink
+          (PredicateNode "has_current_symbol")
+          (ListLink
+              (GeneNode gene)
+              (VariableNode "$g")      
+          )
+        )
+        (VariableNode "$g")
+      ))
+    )))
+    (if (equal? cur '()) '() (string-append gene "=>" (cog-name (car cur))))
+    )
+  )gene-list)))
+  (flatten current)  
+))
+
+(define-public (check-outdate-genes gene-list) 
+  (let ([symbol (find-current-symbol gene-list)])
+    (if (equal? symbol '())
+      "0"
+      (string-append "1:" "The following gene symbols are outdated, here are the current " (string-join symbol ","))
+    )
+  )
+)
+
 (define-public (build-pubmed-url nodename)
  (string-append "https://www.ncbi.nlm.nih.gov/pubmed/?term=" (cadr (string-split nodename #\:)))
 )

--- a/tests/main-tests.scm
+++ b/tests/main-tests.scm
@@ -30,5 +30,7 @@
 
 (test-equal "find-genes" "0" (find-genes (list "IGF1" "TF")))
 
+(test-equal "delete-genes" #t (cog-delete-recursive (GeneNode "IGF")))
+
 (clear)
 (test-end "main")

--- a/tests/main-tests.scm
+++ b/tests/main-tests.scm
@@ -24,5 +24,11 @@
 
 (test-equal "protein-goterm" 86 (length (cog-outgoing-set (find-proteins-goterm (GeneNode "IGF1") namespace 0))))
 
+(primitive-load "annotation/pln_rule.scm")
+
+(test-equal "current_vs_prev_symbols" (ListLink) (find-protein-form (GeneNode "NOV")))
+
+(test-equal "find-genes" "0" (find-genes (list "IGF1" "TF")))
+
 (clear)
 (test-end "main")


### PR DESCRIPTION
- Apply PLN rule to get rid of outdated gene symbols
- Suggest user to use the current gene symbol
- Remove unknown gene symbols (created while searching) from the atomspace
- Test cases to check the functionalities added