### PR TITLE
Fix warning about CLEANFILES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ TESTS = \
 TEST_EXTENSIONS = .scm
 
 SCM_LOG_DRIVER = \
-    $(top_builddir)/env	\
+	$(top_builddir)/env	\
 	$(GUILE) --no-auto-compile -e main	\
 	$(top_srcdir)/build-aux/test-driver.scm
 
@@ -35,12 +35,13 @@ AM_SCM_LOG_FLAGS = --no-auto-compile -L $(top_srcdir)
 
 AM_COLOR_TESTS=always
 
-CLEANFILES = \
+CLEANFILES += \
 	$(GOBJECTS)	\
 	$(TESTS:tests/%.scm=%.log)	\
-	*.log *.tar.gz
+	*.log
 
 
-EXTRA_DIST =  $(SOURCES) \
-	          $(TESTS)	\
-              build-aux/test-driver.scm	
+EXTRA_DIST = \
+	$(SOURCES) \
+	$(TESTS)	\
+	build-aux/test-driver.scm


### PR DESCRIPTION
Also cleanup whitespace.
Also, do NOT remove tar.gz files as a part of `make clean`.