### PR TITLE
The query module is obsolete!

### DIFF
--- a/opencog_deps
+++ b/opencog_deps
@@ -3,7 +3,6 @@
 (debug-enable 'backtrace)
 (read-enable 'positions)
 (use-modules (opencog))
-(use-modules (opencog query))
 (use-modules (opencog exec))
 (use-modules (opencog bioscience))
 (use-modules


### PR DESCRIPTION
This gets rid of the first warning in #66