### PR TITLE
Remove call to delete-duplicates

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -138,7 +138,6 @@
           ]
       )
       )))
-       (delete-duplicates parents)
        (append (node-info g) parents)
     )
 ))


### PR DESCRIPTION
There are two problems with this call: First, `delete-dup-atoms`
is orderes of magnitude faster, and second, the return value is
ignored, so this is just a CPU-wasting call.  See issue #82.

Also, some casual printouts suggests that there aren't any duplicates,
anyway.