### PR TITLE
Cache pathway-gene-interactors for 3x speedup!

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -611,8 +611,16 @@
         )))	
 ))
 
+;; Cache previous results, so that they are not recomputed again,
+;; if the results are already known. Note that this functin accounts
+;; for about 60% of the total execution time of `gene-pathway-annotation`
+;; so any caching at all is a win. In a test of 681 genes, this offers
+;; a 3x speedup in run time.
+(define-public pathway-gene-interactors
+	(make-afunc-cache do-pathway-gene-interactors))
+
 ;; Gene interactors for genes in the pathway
-(define-public pathway-gene-interactors 
+(define-public do-pathway-gene-interactors
   (lambda (pw)
   (cog-outgoing-set (cog-execute! (BindLink
     (VariableList

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -611,16 +611,8 @@
         )))	
 ))
 
-;; Cache previous results, so that they are not recomputed again,
-;; if the results are already known. Note that this functin accounts
-;; for about 60% of the total execution time of `gene-pathway-annotation`
-;; so any caching at all is a win. In a test of 681 genes, this offers
-;; a 3x speedup in run time.
-(define-public pathway-gene-interactors
-	(make-afunc-cache do-pathway-gene-interactors))
-
 ;; Gene interactors for genes in the pathway
-(define-public do-pathway-gene-interactors
+(define do-pathway-gene-interactors
   (lambda (pw)
   (cog-outgoing-set (cog-execute! (BindLink
     (VariableList
@@ -644,6 +636,14 @@
 		  ))
   ))
 )))
+
+;; Cache previous results, so that they are not recomputed again,
+;; if the results are already known. Note that this functin accounts
+;; for about 60% of the total execution time of `gene-pathway-annotation`
+;; so any caching at all is a win. In a test of 681 genes, this offers
+;; a 3x speedup in run time.
+(define-public pathway-gene-interactors
+	(make-afunc-cache do-pathway-gene-interactors))
 
 (define-public find-protein-form
   (lambda (gene)


### PR DESCRIPTION
Cache previous results, so that they are not recomputed again,
if the results are already known. Note that this functin accounts
for about 60% of the total execution time of `gene-pathway-annotation`
so any caching at all is a win. In a test of 681 genes, this offers
a 3x speedup in run time. (On my machine, execution time went from
61801 seconds to 19180 seconds)

Of course, on any one gene, or small handful of genes, there will
be zero speedup; there has to be a cache-hit to see any benefit,
i.e. there have to be multiple genes that share teh same pathways.