### PR TITLE
Simplify parser

### DIFF
--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -102,15 +102,9 @@ atomspace."
 )
 
 (define-public (annotate-genes genes-list file-name request)
-  (parameterize ( (nodes '()) 
-                  (edges '()) 
-                  (atoms '()) 
-                  (biogrid-genes '())
-                  (biogrid-pairs '())
-                  (biogrid-pairs-pathway '())
-                  (annotation "")
-                  (prev-annotation "")
-              )
+  (parameterize ((biogrid-genes '())
+                 (biogrid-pairs '())
+                 (biogrid-pairs-pathway '()))
       (let* (
         [fns (parse-request genes-list file-name request)]
         [result (par-map (lambda (x) (x)) fns)]

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -104,7 +104,7 @@
                       (let* ([info (node-data (car *nodes*))]
                              [old-loc (node-info-location info)]
                              [new-loc (cadr lns)])
-                        (if (string=? old-loc "")
+                        (if (string-null? old-loc)
                             (node-info-location-set! info new-loc)
                             (if (not (string-contains old-loc new-loc))
                                 (node-info-location-set! info (string-append old-loc "," new-loc))))

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -112,30 +112,18 @@
                (_ (error "Unrecognized predicate" predicate))))
 
 (define-public (handle-ln node-a node-b link)
-        (begin 
-             (set! *edges* (append (list (create-edge node-a node-b link (list *annotation*) "" link)) *edges*))
-            '()
-        )
-)
+  (set! *edges* (append (list (create-edge node-a node-b link (list *annotation*) "" link)) *edges*))
+  '())
 
 (define-public (handle-list-ln node)
-    (let ()
-            (cond [(string? node) (list node)]
-                    [else   (flatten node)]
-            )
-        
-    )
-)
+  (cond [(string? node) (list node)]
+        [else   (flatten node)]))
 
 (define-public (handle-node node)
-      (begin (if (member node annts)
-          (begin 
-              (set! *prev-annotation* *annotation*)
-              (set! *annotation* node)
-          )
-      ))
-      node   
-)
+  (when (member node annts)
+    (set! *prev-annotation* *annotation*)
+    (set! *annotation* node))
+  node)
 
 (define* (atomese-parser port #:optional (mode #f))
     (let* (

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -20,22 +20,10 @@
 
 (define-module (annotation parser)
     #:use-module (annotation util)
-    #:use-module (annotation main)
     #:use-module (nyacc lalr)
     #:use-module (nyacc lex)
     #:use-module (nyacc parse)
-    #:use-module (opencog)
-    #:use-module (opencog exec)
-    #:use-module (opencog bioscience)
     #:use-module (json)
-    #:use-module (ice-9 optargs)
-;    #:use-module (rnrs base)
-    #:use-module (rnrs exceptions)
-    #:use-module (ice-9 textual-ports)
-    #:use-module (ice-9 regex)
-    #:use-module (ice-9 threads)
-    #:use-module (srfi srfi-1)
-    #:use-module (ice-9 atomic)
     #:use-module (ice-9 match)
     #:export (atomese-parser
             handle-node

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -41,64 +41,64 @@
 (define *prev-annotation* "")
 
 (define-public (handle-eval-ln predicate lns)
-             (match predicate
-               ((or "expresses"
-                    "interacts_with"
-                    "inferred_interaction"
-                    "transcribed_to"
-                    "translated_to")
-                (set! *edges* (cons (create-edge (cadr lns)
-                                                 (car lns)
-                                                 predicate
-                                                 (list *annotation*)
-                                                 "" predicate)
-                                    *edges*))
-                '())
-               ((or "has_name" "GO_name")
-                (if (member (car lns) *atoms*)
-                    (when (and (not (string-null? *prev-annotation*))
-                               (not (string=? *prev-annotation* *annotation*)))
-                      (let* ([node (car (filter (lambda (n)
-                                                  (string=? (node-info-id (node-data n))
-                                                            (car lns)))
-                                                *nodes*))]
-                             [node-group (node-info-group (node-data node))])
-                        ;;check if it is the same node and exit if it is
-                        (when (string=? (car node-group) *annotation*)
-                          '())
-                        (node-info-group-set! (node-data node)
-                                              (append node-group (list *annotation*)))))
-                    (begin
-                      (set! *nodes*
-                            (cons (create-node (car lns) (cadr lns)
-                                               (build-desc-url (car lns))
-                                               ""
-                                               (list *annotation*)
-                                               (find-subgroup (car lns)))
-                                  *nodes*))
-                      (set! *atoms*
-                            (cons (car lns) *atoms*))))
-                '())
-               ("GO_namespace"
-                (if (and (member (car lns) *atoms*)
-                         (string=? (car lns) (node-info-id (node-data (car *nodes*)))))
-                    (node-info-subgroup-set! (node-data (car *nodes*)) (cadr lns)))
-                '())
-               ("has_pubmedID"
-                (edge-info-pubid-set! (edge-data (car *edges*)) (string-join lns ","))
-                '())
-               ("has_location"
-                (when (and (member (car lns) *atoms*)
-                           (string=? (car lns) (node-info-id (node-data (car *nodes*)))))
-                      (let* ([info (node-data (car *nodes*))]
-                             [old-loc (node-info-location info)]
-                             [new-loc (cadr lns)])
-                        (if (string-null? old-loc)
-                            (node-info-location-set! info new-loc)
-                            (unless (string-contains old-loc new-loc)
-                              (node-info-location-set! info (string-append old-loc "," new-loc))))
-                        '())))
-               (_ (error "Unrecognized predicate" predicate))))
+  (match predicate
+    ((or "expresses"
+         "interacts_with"
+         "inferred_interaction"
+         "transcribed_to"
+         "translated_to")
+     (set! *edges* (cons (create-edge (cadr lns)
+                                      (car lns)
+                                      predicate
+                                      (list *annotation*)
+                                      "" predicate)
+                         *edges*))
+     '())
+    ((or "has_name" "GO_name")
+     (if (member (car lns) *atoms*)
+         (when (and (not (string-null? *prev-annotation*))
+                    (not (string=? *prev-annotation* *annotation*)))
+           (let* ([node (car (filter (lambda (n)
+                                       (string=? (node-info-id (node-data n))
+                                                 (car lns)))
+                                     *nodes*))]
+                  [node-group (node-info-group (node-data node))])
+             ;;check if it is the same node and exit if it is
+             (when (string=? (car node-group) *annotation*)
+               '())
+             (node-info-group-set! (node-data node)
+                                   (append node-group (list *annotation*)))))
+         (begin
+           (set! *nodes*
+                 (cons (create-node (car lns) (cadr lns)
+                                    (build-desc-url (car lns))
+                                    ""
+                                    (list *annotation*)
+                                    (find-subgroup (car lns)))
+                       *nodes*))
+           (set! *atoms*
+                 (cons (car lns) *atoms*))))
+     '())
+    ("GO_namespace"
+     (if (and (member (car lns) *atoms*)
+              (string=? (car lns) (node-info-id (node-data (car *nodes*)))))
+         (node-info-subgroup-set! (node-data (car *nodes*)) (cadr lns)))
+     '())
+    ("has_pubmedID"
+     (edge-info-pubid-set! (edge-data (car *edges*)) (string-join lns ","))
+     '())
+    ("has_location"
+     (when (and (member (car lns) *atoms*)
+                (string=? (car lns) (node-info-id (node-data (car *nodes*)))))
+       (let* ([info (node-data (car *nodes*))]
+              [old-loc (node-info-location info)]
+              [new-loc (cadr lns)])
+         (if (string-null? old-loc)
+             (node-info-location-set! info new-loc)
+             (unless (string-contains old-loc new-loc)
+               (node-info-location-set! info (string-append old-loc "," new-loc))))
+         '())))
+    (_ (error "Unrecognized predicate" predicate))))
 
 (define-public (handle-ln node-a node-b link)
   (set! *edges* (cons (create-edge node-a node-b link (list *annotation*) "" link) *edges*))

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -59,12 +59,12 @@
                     "inferred_interaction"
                     "transcribed_to"
                     "translated_to")
-                (set! *edges* (append (list (create-edge (cadr lns)
-                                                         (car lns)
-                                                         predicate
-                                                         (list *annotation*)
-                                                         "" predicate))
-                                      *edges*))
+                (set! *edges* (cons (create-edge (cadr lns)
+                                                 (car lns)
+                                                 predicate
+                                                 (list *annotation*)
+                                                 "" predicate)
+                                    *edges*))
                 '())
                ((or "has_name" "GO_name")
                 (if (member (car lns) *atoms*)
@@ -80,14 +80,14 @@
                                                 (append node-group (list *annotation*)))))
                     (begin
                       (set! *nodes*
-                            (append (list (create-node (car lns) (cadr lns)
-                                                       (build-desc-url (car lns))
-                                                       ""
-                                                       (list *annotation*)
-                                                       (find-subgroup (car lns))))
-                                    *nodes*))
+                            (cons (create-node (car lns) (cadr lns)
+                                               (build-desc-url (car lns))
+                                               ""
+                                               (list *annotation*)
+                                               (find-subgroup (car lns)))
+                                  *nodes*))
                       (set! *atoms*
-                            (append (list (car lns)) *atoms*))))
+                            (cons (car lns) *atoms*))))
                 '())
                ("GO_namespace"
                 (if (and (member (car lns) *atoms*)
@@ -112,7 +112,7 @@
                (_ (error "Unrecognized predicate" predicate))))
 
 (define-public (handle-ln node-a node-b link)
-  (set! *edges* (append (list (create-edge node-a node-b link (list *annotation*) "" link)) *edges*))
+  (set! *edges* (cons (create-edge node-a node-b link (list *annotation*) "" link) *edges*))
   '())
 
 (define-public (handle-list-ln node)

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -56,16 +56,18 @@
                 '())
                ((or "has_name" "GO_name")
                 (if (member (car lns) *atoms*)
-                    (if (and (not (string-null? *prev-annotation*))
-                             (not (string=? *prev-annotation* *annotation*)))
-                        (let* ([node (car (filter (lambda (n) (string=? (node-info-id (node-data n)) (car lns)))
-                                                  *nodes*))]
-                               [node-group (node-info-group (node-data node))])
-                          ;;check if it is the same node and exit if it is
-                          (if (string=? (car node-group) *annotation*)
-                              '())
-                          (node-info-group-set! (node-data node)
-                                                (append node-group (list *annotation*)))))
+                    (when (and (not (string-null? *prev-annotation*))
+                               (not (string=? *prev-annotation* *annotation*)))
+                      (let* ([node (car (filter (lambda (n)
+                                                  (string=? (node-info-id (node-data n))
+                                                            (car lns)))
+                                                *nodes*))]
+                             [node-group (node-info-group (node-data node))])
+                        ;;check if it is the same node and exit if it is
+                        (when (string=? (car node-group) *annotation*)
+                          '())
+                        (node-info-group-set! (node-data node)
+                                              (append node-group (list *annotation*)))))
                     (begin
                       (set! *nodes*
                             (cons (create-node (car lns) (cadr lns)
@@ -86,17 +88,16 @@
                 (edge-info-pubid-set! (edge-data (car *edges*)) (string-join lns ","))
                 '())
                ("has_location"
-                (begin
-                  (if (and (member (car lns) *atoms*)
+                (when (and (member (car lns) *atoms*)
                            (string=? (car lns) (node-info-id (node-data (car *nodes*)))))
                       (let* ([info (node-data (car *nodes*))]
                              [old-loc (node-info-location info)]
                              [new-loc (cadr lns)])
                         (if (string-null? old-loc)
                             (node-info-location-set! info new-loc)
-                            (if (not (string-contains old-loc new-loc))
-                                (node-info-location-set! info (string-append old-loc "," new-loc))))
-                        '()))))
+                            (unless (string-contains old-loc new-loc)
+                              (node-info-location-set! info (string-append old-loc "," new-loc))))
+                        '())))
                (_ (error "Unrecognized predicate" predicate))))
 
 (define-public (handle-ln node-a node-b link)

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -35,15 +35,10 @@
 	          create-edge)
 )
 
-;;Define the parameters needed for parsing and GGI
-(define-public nodes (make-parameter '()))
-(define-public edges (make-parameter '()))
-(define-public atoms (make-parameter '()))
+;;Define the parameters needed for GGI
 (define-public biogrid-genes (make-parameter '()))
 (define-public biogrid-pairs (make-parameter '()))
 (define-public biogrid-pairs-pathway (make-parameter '()))
-(define-public annotation (make-parameter ""))
-(define-public prev-annotation (make-parameter ""))
 
 (define (get-name atom)
  (if (> (length atom) 0)


### PR DESCRIPTION
This is a very conservative set of changes to the parser module intended to simplify and clarify the intent of the code.

With these changes the tests still pass, but the parser tests are too simple to catch any serious problems.

I thought it would make sense to simplify the code before attempting to rewrite it in terms of `read`.