### PR TITLE
Whitelist the annotation functions that are executed

### DIFF
--- a/tests/main-tests.scm
+++ b/tests/main-tests.scm
@@ -24,7 +24,13 @@
 
 (define req "[{\"function_name\": \"gene-pathway-annotation\", \"filters\": [{\"filter\": \"pathway\", \"value\": \"smpdb reactome\"},{\"filter\": \"include_prot\", \"value\": \"True\"}, {\"filter\": \"include_sm\", \"value\": \"False\"},{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"}, {\"filter\": \"biogrid\", \"value\": \"0\"}]}, {\"function_name\": \"gene-go-annotation\", \"filters\": [{\"filter\": \"namespace\", \"value\": \"biological_process cellular_component molecular_function\"}, {\"filter\": \"parents\", \"value\": \"0\"}, {\"filter\": \"protein\", \"value\": \"True\"}]}, {\"function_name\": \"include-rna\", \"filters\": [{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"},{\"filter\": \"protein\", \"value\": \"1\"}]},{\"function_name\": \"biogrid-interaction-annotation\", \"filters\": [{\"filter\": \"interaction\", \"value\": \"Proteins\"}]}]")
 
+(define invalid-req "[{\"function_name\": \"unknown-function\", \"filters\": [{\"filter\": \"pathway\", \"value\": \"smpdb reactome\"},{\"filter\": \"include_prot\", \"value\": \"True\"}, {\"filter\": \"include_sm\", \"value\": \"False\"},{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"}, {\"filter\": \"biogrid\", \"value\": \"0\"}]}]")
+
 (test-equal "parse-request" 5 (length (parse-request (list "IGF1") "Dfaer" req)))
+
+;;This should only return a single list which contains the `gene-info` function. 
+;;This is because the function name `unknown-function` is not in the list `annotation-functions`
+(test-equal "validate-functions" 1 (length (parse-request (list "IGF1") "Dfaer" invalid-req)))
 
 (test-assert "annotate-genes" (string? (annotate-genes (list "IGF1") "Dfaer" req)))
 


### PR DESCRIPTION
This change adds restrictions on the functions that can be executed in the JSON request and prevents from executing arbitrary functions. 