### PR TITLE
further simplification of pathway-hierarchy

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -352,24 +352,22 @@ translates to."
 " pathway-hierarchy -- Find hierarchy of the reactome pathway."
 
    (define parents (run-query
-      (Get (VariableNode "$parentpw")
-         (Inheritance pw (Variable "$parentpw")))))
+      (Get (Variable "$parentpw") (Inheritance pw (Variable "$parentpw")))))
 
    (define childs (run-query
-      (Get (VariableNode "$childpw")
-         (Inheritance (Variable "$childpw") pw))))
-
-   (define (check-pathway pw parent-pw lst)
-      (if (and (member parent-pw lst) (member pw lst))
-         (Inheritance pw parent-pw)))
+      (Get (Variable "$childpw") (Inheritance (Variable "$childpw") pw))))
 
    (define res-parent
-       (map (lambda (parent-pw) (check-pathway pw parent-pw lst)) parents))
+      (filter-map (lambda (parent-pw)
+            (if (member parent-pw lst) (Inheritance pw parent-pw) #f))
+         parents))
 
    (define res-child
-      (map (lambda (child-pw) (check-pathway child-pw pw lst)) childs)]
+      (filter-map (lambda (child-pw)
+            (if (member child-pw lst) (Inheritance child-pw pw) #f))
+         childs))
 
-   (append res-parent res-child)))
+   (append res-parent res-child))
 
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -349,45 +349,30 @@ translates to."
     ((name . rest) name)))
 
 (define-public (pathway-hierarchy pw lst)
-  "Find hierarchy of the reactome pathway."
-  (let ([res-parent
-         (run-query (BindLink
-                     (VariableNode "$parentpw")
-                     (InheritanceLink
-                      pw
-                      (VariableNode "$parentpw"))
-                     (ExecutionOutputLink
-                      (GroundedSchemaNode "scm: check-pathway")
-                      (ListLink
-                       pw
-                       (VariableNode "$parentpw")
-                       (ListLink lst)))))]
-        [res-child
-         (run-query (BindLink
-                     (VariableNode "$parentpw")
-                     (InheritanceLink
-                      (VariableNode "$parentpw")
-                      pw)
-                     (ExecutionOutputLink
-                      (GroundedSchemaNode "scm: check-pathway")
-                      (ListLink
-                       (VariableNode "$parentpw")
-                       pw
-                       (ListLink lst)))))])
-    (append res-parent res-child)))
+" pathway-hierarchy -- Find hierarchy of the reactome pathway."
 
-(define-public check-pathway
-  (lambda (pw parent-pw lst)
-    (if (and (member parent-pw (cog-outgoing-set lst)) (member pw (cog-outgoing-set lst)))
-    (ListLink
-      (InheritanceLink
-      pw
-      parent-pw)
-    ))
-))
+   (define parents (run-query
+      (Get (VariableNode "$parentpw")
+         (Inheritance pw (Variable "$parentpw")))))
 
-;; Finds molecules (proteins or chebi's) in a pathway 
+   (define childs (run-query
+      (Get (VariableNode "$childpw")
+         (Inheritance (Variable "$childpw") pw))))
+
+   (define (check-pathway pw parent-pw lst)
+      (if (and (member parent-pw lst) (member pw lst))
+         (Inheritance pw parent-pw)))
+
+   (define res-parent
+       (map (lambda (parent-pw) (check-pathway pw parent-pw lst)) parents))
+
+   (define res-child
+      (map (lambda (child-pw) (check-pathway child-pw pw lst)) childs)]
+
+   (append res-parent res-child)))
+
 (define-public (find-mol path identifier)
+" Finds molecules (proteins or chebi's) in a pathway"
   (run-query (BindLink
     (TypedVariable (Variable "$a") (TypeNode 'MoleculeNode))
     (AndLink

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -354,7 +354,7 @@ translates to."
 	(filter
 		(lambda (inhlink)
 			(and (member (gar inhlink) lst) (member (gdr inhlink) lst)))
-		(get-incoming-by-type pw 'InheritanceLink)))
+		(cog-incoming-by-type pw 'InheritanceLink)))
 
 
 (define-public (find-mol path identifier)

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -351,23 +351,11 @@ translates to."
 (define-public (pathway-hierarchy pw lst)
 " pathway-hierarchy -- Find hierarchy of the reactome pathway."
 
-   (define parents (run-query
-      (Get (Variable "$parentpw") (Inheritance pw (Variable "$parentpw")))))
+	(filter
+		(lambda (inhlink)
+			(and (member (gar inhlink) lst) (member (gdr inhlink) lst)))
+		(get-incoming-by-type pw 'InheritanceLink)))
 
-   (define childs (run-query
-      (Get (Variable "$childpw") (Inheritance (Variable "$childpw") pw))))
-
-   (define res-parent
-      (filter-map (lambda (parent-pw)
-            (if (member parent-pw lst) (Inheritance pw parent-pw) #f))
-         parents))
-
-   (define res-child
-      (filter-map (lambda (child-pw)
-            (if (member child-pw lst) (Inheritance child-pw pw) #f))
-         childs))
-
-   (append res-parent res-child))
 
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"


### PR DESCRIPTION
Please apply pull req #126 first, and verify that it works as expected.
After that pull req, visual inspection shows that all that the code is
doing is a fetch of all of the inheritance links, and a filter. That can be
done directly, in a much speedier and immediate way, as done here.

Part of the simplification called for in #105.