### PR TITLE
Optimize generate-interactors for performance.

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -721,39 +721,22 @@ translates to."
 )
 
 (define-public (generate-interactors path var1 var2)
-      (if (not (string=? (cog-name var1) (cog-name var2)))
-      
-      (let ([pairs (find (lambda (x) (or (equal? (cons (cog-name var1) (cog-name var2)) x)
-                                          (equal? (cons (cog-name var2) (cog-name var1)) x)
-                                      )
-        
-                  ) (biogrid-pairs-pathway))]
-          )
-          (if pairs
-            '()
-            (let (
-              [output (find-pubmed-id var1 var2)]
-              )
-                (biogrid-pairs-pathway (append (biogrid-pairs-pathway) (list (cons (cog-name var1) (cog-name var2)))))
-               (if (null? output) 
-                (EvaluationLink 
-                  (PredicateNode "interacts_with") 
-                  (ListLink var1 var2))
-                (EvaluationLink
-                  (PredicateNode "has_pubmedID")
-                  (ListLink 
-                    (EvaluationLink 
-                        (PredicateNode "interacts_with") 
-                        (ListLink var1 var2))  
-                          output)
-                        )
-                )
-              )
-            )
-          )
-        '()
-    )
-
+	; (biogrid-reported-pathways) is a cache of the intercations that have
+	; already been handled. Defined in util.scm and cleared in main.scm.
+	(if (or (equal? var1 var2)
+			((biogrid-reported-pathways) (Set var1 var2))) '()
+		(let ([output (find-pubmed-id var1 var2)])
+			(if (null? output)
+				(EvaluationLink
+					(PredicateNode "interacts_with")
+					(ListLink var1 var2))
+				(EvaluationLink
+					(PredicateNode "has_pubmedID")
+					(ListLink
+						(EvaluationLink
+							(PredicateNode "interacts_with")
+							(ListLink var1 var2))
+						output)))))
 )
 
 ;;                           

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -721,7 +721,7 @@ translates to."
 )
 
 (define-public (generate-interactors path var1 var2)
-	; (biogrid-reported-pathways) is a cache of the intercations that have
+	; (biogrid-reported-pathways) is a cache of the interactions that have
 	; already been handled. Defined in util.scm and cleared in main.scm.
 	(if (or (equal? var1 var2)
 			((biogrid-reported-pathways) (Set var1 var2))) '()

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -113,7 +113,7 @@ atomspace."
 (define-public (annotate-genes genes-list file-name request)
   (parameterize ((biogrid-genes '())
                  (biogrid-pairs '())
-                 (biogrid-pairs-pathway '()))
+                 (biogrid-reported-pathways (make-atom-set)))
     (let* ([fns (parse-request genes-list file-name request)]
            [result (par-map (lambda (x) (x)) fns)] )
       (scm->json-string

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -111,8 +111,8 @@ atomspace."
 )
 
 (define-public (annotate-genes genes-list file-name request)
-  (parameterize ((biogrid-genes '())
-                 (biogrid-pairs '())
+  (parameterize ((biogrid-genes (make-atom-set))
+                 (biogrid-pairs (make-atom-set))
                  (biogrid-reported-pathways (make-atom-set)))
     (let* ([fns (parse-request genes-list file-name request)]
            [result (par-map (lambda (x) (x)) fns)] )

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -39,7 +39,7 @@
 ;;Define the parameters needed for GGI
 (define-public biogrid-genes (make-parameter '()))
 (define-public biogrid-pairs (make-parameter '()))
-(define-public biogrid-pairs-pathway (make-parameter '()))
+(define-public biogrid-reported-pathways (make-parameter (make-atom-set)))
 
 (define (get-name atom)
  (if (> (length atom) 0)

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -37,8 +37,8 @@
 )
 
 ;;Define the parameters needed for GGI
-(define-public biogrid-genes (make-parameter '()))
-(define-public biogrid-pairs (make-parameter '()))
+(define-public biogrid-genes (make-parameter (make-atom-set)))
+(define-public biogrid-pairs (make-parameter (make-atom-set)))
 (define-public biogrid-reported-pathways (make-parameter (make-atom-set)))
 
 (define (get-name atom)


### PR DESCRIPTION
After this patch, as reported in issue #103, this function now runs
150x faster, which allows pathway-gene-interactors tu run more than
twice as fast.  See also issue  #98 for a general overview.