### PR TITLE
Improve caching performance in `generate-result`

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -576,10 +576,11 @@ translates to."
 ;; Grounded schema node to add info about matched variable nodes
 
 (define-public (generate-result gene-a gene-b prot go rna) 
-    (if  
-      (and (not (equal? (cog-type gene-a) 'VariableNode)) (not (equal? (cog-type gene-b) 'VariableNode))
-        )  
-      (let* (
+	(if
+		(or (equal? (cog-type gene-a) 'VariableNode)
+		    (equal? (cog-type gene-b) 'VariableNode))
+		(ListLink)
+		(let* (
             [output (find-pubmed-id gene-a gene-b)]
             [res (flatten (map (lambda (x) 
                               (if (not (member (cog-name x) (biogrid-genes)))
@@ -698,7 +699,6 @@ translates to."
               )
           )
       )
-  (ListLink)
 )
     
 )

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -573,23 +573,28 @@ translates to."
   ))
 )
 
-;; Grounded schema node to add info about matched variable nodes
-
 (define-public (generate-result gene-a gene-b prot go rna)
+"
+  generate-result -- add info about matched variable nodes
+
+  `prot` is either (NumberNode 0) or (NumberNode 1)
+      which is used to indicate whether or not protein interactions
+      should be computed.
+"
 	(if
 		(or (equal? (cog-type gene-a) 'VariableNode)
 		    (equal? (cog-type gene-b) 'VariableNode))
 		(ListLink)
 		(let* (
-            [prot-name  (cog-name prot)]
-            [is-one  (= 1 (string->number prot-name))]
+            [do-prot-str  (cog-name prot)]
+            [do-protein  (= 1 (string->number do-prot-str))]
 
 				[already-done-a ((biogrid-genes) gene-a)]
 				[already-done-b ((biogrid-genes) gene-b)]
             [already-done-pair ((biogrid-pairs) (List gene-a gene-b))]
 
 				[output (find-pubmed-id gene-a gene-b)]
-            [interaction (if is-one
+            [interaction (if do-protein
                 (ListLink
                   (build-interaction gene-a gene-b output "interacts_with")
                   (build-interaction
@@ -627,11 +632,11 @@ translates to."
                     (if (= 0 (cog-arity rna)) '()
                        (List
                           (Concept "rna-annotation")
-                          (find-rna gene-a crna-name ncrna-name prot-name)
-                          (find-rna gene-b crna-name ncrna-name prot-name)
+                          (find-rna gene-a crna-name ncrna-name do-prot-str)
+                          (find-rna gene-b crna-name ncrna-name do-prot-str)
                           (List (Concept "biogrid-interaction-annotation")))
                    )])
-                      (if is-one
+                      (if do-protein
                         (let ([coding-prot-a (find-protein-form gene-a)]
                               [coding-prot-b (find-protein-form gene-b)])
                         (if (or (equal? coding-prot-a (ListLink))
@@ -680,10 +685,10 @@ translates to."
                      (if (= 0 (cog-arity rna)) '()
                         (List
                            (Concept "rna-annotation")
-                           (find-rna gene-x crna-name ncrna-name prot-name)
+                           (find-rna gene-x crna-name ncrna-name do-prot-str)
                            (List (Concept "biogrid-interaction-annotation")))
                     )])
-                 (if is-one
+                 (if do-protein
                     (let ([coding-prot (find-protein-form gene-x)])
                        (if (equal? coding-prot (ListLink))
                           (ListLink)

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -575,20 +575,17 @@ translates to."
 
 ;; Grounded schema node to add info about matched variable nodes
 
-(define-public (generate-result gene-a gene-b prot go rna) 
+(define-public (generate-result gene-a gene-b prot go rna)
 	(if
 		(or (equal? (cog-type gene-a) 'VariableNode)
 		    (equal? (cog-type gene-b) 'VariableNode))
 		(ListLink)
 		(let* (
-            [output (find-pubmed-id gene-a gene-b)]
-            [res (flatten (map (lambda (x) 
-                              (if (not (member (cog-name x) (biogrid-genes)))
-                                  (cog-name x)
-                                  '()
-                              ) 
-              )  (list gene-a gene-b))) ]
-            [interaction (if (= 1 (string->number (cog-name prot))) 
+            [prot-name  (cog-name prot)]
+				[already-done-a ((biogrid-genes) gene-a)]
+				[already-done-b ((biogrid-genes) gene-b)]
+				[output (find-pubmed-id gene-a gene-b)]
+            [interaction (if (= 1 (string->number (cog-name prot)))
                 (ListLink
                   (build-interaction gene-a gene-b output "interacts_with")
                   (build-interaction (find-protein-form gene-a) (find-protein-form gene-b) output "inferred_interaction"))
@@ -596,42 +593,50 @@ translates to."
             [namespace (if (null? (cog-outgoing-set go)) '() (car (cog-outgoing-set go)))]
             [parent (if (null? (cog-outgoing-set go)) '() (cadr (cog-outgoing-set go)))]
             [pairs (find (lambda (x) (equal? x (cons (cog-name gene-a) (cog-name gene-b)))) (biogrid-pairs))]
-            [crna (if (not (null? (cog-outgoing-set rna))) (car (cog-outgoing-set rna)))]
-            [ncrna (if (not (null? (cog-outgoing-set rna))) (cadr (cog-outgoing-set rna)))]
-          )
-          (if (null? interaction)
-            (ListLink)
+            [crna  (if (= 0 (cog-arity rna)) '() (gar rna))]
+            [ncrna (if (= 0 (cog-arity rna)) '() (gadr rna))]
           )
           (if (not pairs)
             (biogrid-pairs (append (biogrid-pairs) (list (cons (cog-name gene-a) (cog-name gene-b)))))
           )
-          (match res
-              ((a b)
-                  (begin 
-                  (let ([go-cross-annotation (if (null? namespace) '() 
-                        (ListLink (ConceptNode "gene-go-annotation")
-                        (map (lambda (gene) (find-go-term (GeneNode gene) (string-split (cog-name namespace) #\ ) (string->number (cog-name parent))))(list a b))
-                        (ListLink (ConceptNode "biogrid-interaction-annotation")))
-                        )]
-                        [rna-cross-annotation (if (null? (cog-outgoing-set rna)) '() 
-                        (ListLink (ConceptNode "rna-annotation") 
-                        (map (lambda (gene) (find-rna (GeneNode gene) (cog-name crna) (cog-name ncrna) (cog-name prot))) (list a b))
-                        (ListLink (ConceptNode "biogrid-interaction-annotation")))
-                        )])
-                      (biogrid-genes (append (list a b) (biogrid-genes)))
-                      (if (= 1 (string->number (cog-name prot)))
-                        (let ([coding-prot-a (find-protein-form (GeneNode a))]
-                              [coding-prot-b (find-protein-form (GeneNode b))])
-                        (if (or (equal? coding-prot-a (ListLink)) (equal? coding-prot-b (ListLink)))
+          ;; Neither gene has been done yet.
+          (cond
+              ((and (not already-done-a) (not already-done-b))
+              (let (
+                 [go-cross-annotation
+                    (if (null? namespace) '()
+                        (List
+                           (Concept "gene-go-annotation")
+                           (find-go-term gene-a
+                              (string-split (cog-name namespace) #\ )
+                              (string->number (cog-name parent)))
+                           (find-go-term gene-b
+                              (string-split (cog-name namespace) #\ )
+                              (string->number (cog-name parent)))
+                           (List (Concept "biogrid-interaction-annotation")))
+                    )]
+                 [rna-cross-annotation
+                    (if (null? (cog-outgoing-set rna)) '()
+                       (List
+                          (Concept "rna-annotation")
+                          (find-rna gene-a (cog-name crna) (cog-name ncrna) prot-name)
+                          (find-rna gene-b (cog-name crna) (cog-name ncrna) prot-name)
+                          (List (Concept "biogrid-interaction-annotation")))
+                   )])
+                      (if (= 1 (string->number prot-name))
+                        (let ([coding-prot-a (find-protein-form gene-a)]
+                              [coding-prot-b (find-protein-form gene-b)])
+                        (if (or (equal? coding-prot-a (ListLink))
+                                (equal? coding-prot-b (ListLink)))
                           (ListLink)
                           (ListLink
                             interaction
-                            (EvaluationLink (PredicateNode "expresses") (ListLink (GeneNode a) coding-prot-a))
-                            (node-info (GeneNode a))
+                            (Evaluation (Predicate "expresses") (List gene-a coding-prot-a))
+                            (node-info gene-a)
                             (node-info coding-prot-a)
                             (locate-node coding-prot-a)
-                            (EvaluationLink (PredicateNode "expresses") (ListLink (GeneNode b) coding-prot-b))
-                            (node-info (GeneNode b))
+                            (Evaluation (Predicate "expresses") (List gene-b coding-prot-b))
+                            (node-info gene-b)
                             (node-info coding-prot-b)
                             (locate-node coding-prot-a)
                             go-cross-annotation
@@ -640,67 +645,61 @@ translates to."
                         ))
                       (ListLink
                           interaction
-                          (node-info (GeneNode a))
-                          (locate-node  (GeneNode a))
-                          (node-info (GeneNode b))
-                          (locate-node  (GeneNode b))
-                          go-cross-annotation
-                          rna-cross-annotation 
-                      )
-                    )
-                  )
-                  )
-              )
-              ((a)
-                  (begin 
-                  (let ([go-cross-annotation (if (null? namespace) '() 
-                        (ListLink (ConceptNode "gene-go-annotation") 
-                        (find-go-term (GeneNode a) (string-split (cog-name namespace) #\ ) (string->number (cog-name parent))) 
-                        (ListLink (ConceptNode "biogrid-interaction-annotation")))
-                        )]
-                        [rna-cross-annotation (if (null? (cog-outgoing-set rna)) '() 
-                        (ListLink (ConceptNode "rna-annotation")
-                        (find-rna (GeneNode a) (cog-name crna) (cog-name ncrna) (cog-name prot))
-                        (ListLink (ConceptNode "biogrid-interaction-annotation")))
-                        )])
-                      (biogrid-genes (append (list a) (biogrid-genes)))
-                      (if (= 1 (string->number (cog-name prot)))
-                        (let ([coding-prot (find-protein-form (GeneNode a))])
-                        (if (equal? coding-prot (ListLink))
-                          (ListLink)
-                          (ListLink
-                            interaction
-                            (EvaluationLink (PredicateNode "expresses") (ListLink (GeneNode a) coding-prot))
-                            (node-info (GeneNode a))
-                            (node-info coding-prot)
-                            (locate-node coding-prot)
-                            go-cross-annotation
-                            rna-cross-annotation 
-                            )
-                        ))
-                      (ListLink
-                          interaction
-                          (node-info (GeneNode a))
-                          (locate-node  (GeneNode a))
+                          (node-info gene-a)
+                          (locate-node gene-a)
+                          (node-info gene-b)
+                          (locate-node gene-b)
                           go-cross-annotation
                           rna-cross-annotation
                       )
-                      )
-                  )
-                )
-              )
-              (()
-                  (if pairs
-                    (ListLink)
+                    )
+                  ))
+
+              ;; One of the two genes is done already. Do the other one.
+              ((or (not already-done-a) (not already-done-b))
+              (let* (
+                  [gene-x (if already-done-a gene-b gene-a)]
+                  [go-cross-annotation
+                     (if (null? namespace) '()
+                        (List
+                           (Concept "gene-go-annotation")
+                           (find-go-term gene-x
+                              (string-split (cog-name namespace) #\ )
+                              (string->number (cog-name parent)))
+                           (List (Concept "biogrid-interaction-annotation")))
+                     )]
+                  [rna-cross-annotation
+                     (if (= 0 (cog-arity rna)) '()
+                        (List
+                           (Concept "rna-annotation")
+                           (find-rna gene-x (cog-name crna) (cog-name ncrna) prot-name)
+                           (List (Concept "biogrid-interaction-annotation")))
+                    )])
+                 (if (= 1 (string->number prot-name))
+                    (let ([coding-prot (find-protein-form gene-x)])
+                       (if (equal? coding-prot (ListLink))
+                          (ListLink)
+                          (ListLink
+                            interaction
+                            (Evaluation (Predicate "expresses") (List gene-x coding-prot))
+                            (node-info gene-x)
+                            (node-info coding-prot)
+                            (locate-node coding-prot)
+                            go-cross-annotation
+                            rna-cross-annotation)
+                    ))
                     (ListLink
-                          interaction
-                      )
-                  )
-              )
+                       interaction
+                       (node-info gene-x)
+                       (locate-node  gene-x)
+                       go-cross-annotation
+                       rna-cross-annotation)
+                )))
+              ;;; Both of the genes have been done.
+              (else (if pairs (ListLink) (ListLink interaction)))
           )
       )
-)
-    
+   )
 )
 
 (define-public (build-interaction interactor-1 interactor-2 pubmed interaction_pred)

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -595,6 +595,8 @@ translates to."
             [pairs (find (lambda (x) (equal? x (cons (cog-name gene-a) (cog-name gene-b)))) (biogrid-pairs))]
             [crna  (if (= 0 (cog-arity rna)) '() (gar rna))]
             [ncrna (if (= 0 (cog-arity rna)) '() (gadr rna))]
+            [crna-name (cog-name crna)]
+            [ncrna-name (cog-name ncrna)]
           )
           (if (not pairs)
             (biogrid-pairs (append (biogrid-pairs) (list (cons (cog-name gene-a) (cog-name gene-b)))))
@@ -619,8 +621,8 @@ translates to."
                     (if (null? (cog-outgoing-set rna)) '()
                        (List
                           (Concept "rna-annotation")
-                          (find-rna gene-a (cog-name crna) (cog-name ncrna) prot-name)
-                          (find-rna gene-b (cog-name crna) (cog-name ncrna) prot-name)
+                          (find-rna gene-a crna-name ncrna-name prot-name)
+                          (find-rna gene-b crna-name ncrna-name prot-name)
                           (List (Concept "biogrid-interaction-annotation")))
                    )])
                       (if (= 1 (string->number prot-name))
@@ -672,7 +674,7 @@ translates to."
                      (if (= 0 (cog-arity rna)) '()
                         (List
                            (Concept "rna-annotation")
-                           (find-rna gene-x (cog-name crna) (cog-name ncrna) prot-name)
+                           (find-rna gene-x crna-name ncrna-name prot-name)
                            (List (Concept "biogrid-interaction-annotation")))
                     )])
                  (if (= 1 (string->number prot-name))

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -581,22 +581,28 @@ translates to."
 		    (equal? (cog-type gene-b) 'VariableNode))
 		(ListLink)
 		(let* (
+            [prot-name  (cog-name prot)]
 				[already-done-a ((biogrid-genes) gene-a)]
 				[already-done-b ((biogrid-genes) gene-b)]
             [already-done-pair ((biogrid-pairs) (List gene-a gene-b))]
+
 				[output (find-pubmed-id gene-a gene-b)]
-            [interaction (if (= 1 (string->number (cog-name prot)))
+            [interaction (if (= 1 (string->number prot-name))
                 (ListLink
                   (build-interaction gene-a gene-b output "interacts_with")
-                  (build-interaction (find-protein-form gene-a) (find-protein-form gene-b) output "inferred_interaction"))
+                  (build-interaction
+                     (find-protein-form gene-a)
+                     (find-protein-form gene-b)
+                     output "inferred_interaction"))
                 (build-interaction gene-a gene-b output "interacts_with"))]
-            [namespace (if (null? (cog-outgoing-set go)) '() (car (cog-outgoing-set go)))]
-            [parent (if (null? (cog-outgoing-set go)) '() (cadr (cog-outgoing-set go)))]
-            [crna  (if (= 0 (cog-arity rna)) '() (gar rna))]
-            [ncrna (if (= 0 (cog-arity rna)) '() (gadr rna))]
+
+            [namespace (if (= 0 (cog-arity go)) '() (gar go))]
+            [parent    (if (= 0 (cog-arity go)) '() (gadr go))]
+
+            [crna      (if (= 0 (cog-arity rna)) '() (gar rna))]
+            [ncrna     (if (= 0 (cog-arity rna)) '() (gadr rna))]
             [crna-name (cog-name crna)]
             [ncrna-name (cog-name ncrna)]
-            [prot-name  (cog-name prot)]
           )
 
           ;; Neither gene has been done yet.

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -545,8 +545,8 @@ translates to."
 ))
 
 ;; Cache previous results, so that they are not recomputed again,
-;; if the results are already known. Note that this functin accounts
-;; for about 60% of the total execution time of `gene-pathway-annotation`
+;; if the results are already known. Note that this function accounts
+;; for about 60% of the total execution time of `gene-pathway-annotation`,
 ;; so any caching at all is a win. In a test of 681 genes, this offers
 ;; a 3x speedup in run time.
 (define-public pathway-gene-interactors
@@ -584,6 +584,10 @@ translates to."
   `rna` may be either an empty ListLink, or may have one, or two
       ConceptNodes in it. If it has two, then first one is the coding RNA,
       and the second one is the non-coding RNA.
+
+      XXX FIXME: these ConceptNodes are used to indicate whether or
+      not the coding or non-coding interactions should be done.
+      The are just set to (ConceptNode "True") to indicate this.
 "
 	(if
 		(or (equal? (cog-type gene-a) 'VariableNode)

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -582,12 +582,14 @@ translates to."
 		(ListLink)
 		(let* (
             [prot-name  (cog-name prot)]
+            [is-one  (= 1 (string->number prot-name))]
+
 				[already-done-a ((biogrid-genes) gene-a)]
 				[already-done-b ((biogrid-genes) gene-b)]
             [already-done-pair ((biogrid-pairs) (List gene-a gene-b))]
 
 				[output (find-pubmed-id gene-a gene-b)]
-            [interaction (if (= 1 (string->number prot-name))
+            [interaction (if is-one
                 (ListLink
                   (build-interaction gene-a gene-b output "interacts_with")
                   (build-interaction
@@ -622,14 +624,14 @@ translates to."
                            (List (Concept "biogrid-interaction-annotation")))
                     )]
                  [rna-cross-annotation
-                    (if (null? (cog-outgoing-set rna)) '()
+                    (if (= 0 (cog-arity rna)) '()
                        (List
                           (Concept "rna-annotation")
                           (find-rna gene-a crna-name ncrna-name prot-name)
                           (find-rna gene-b crna-name ncrna-name prot-name)
                           (List (Concept "biogrid-interaction-annotation")))
                    )])
-                      (if (= 1 (string->number prot-name))
+                      (if is-one
                         (let ([coding-prot-a (find-protein-form gene-a)]
                               [coding-prot-b (find-protein-form gene-b)])
                         (if (or (equal? coding-prot-a (ListLink))
@@ -681,7 +683,7 @@ translates to."
                            (find-rna gene-x crna-name ncrna-name prot-name)
                            (List (Concept "biogrid-interaction-annotation")))
                     )])
-                 (if (= 1 (string->number prot-name))
+                 (if is-one
                     (let ([coding-prot (find-protein-form gene-x)])
                        (if (equal? coding-prot (ListLink))
                           (ListLink)

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -581,9 +581,9 @@ translates to."
 		    (equal? (cog-type gene-b) 'VariableNode))
 		(ListLink)
 		(let* (
-            [prot-name  (cog-name prot)]
 				[already-done-a ((biogrid-genes) gene-a)]
 				[already-done-b ((biogrid-genes) gene-b)]
+            [already-done-pair ((biogrid-pairs) (List gene-a gene-b))]
 				[output (find-pubmed-id gene-a gene-b)]
             [interaction (if (= 1 (string->number (cog-name prot)))
                 (ListLink
@@ -592,15 +592,13 @@ translates to."
                 (build-interaction gene-a gene-b output "interacts_with"))]
             [namespace (if (null? (cog-outgoing-set go)) '() (car (cog-outgoing-set go)))]
             [parent (if (null? (cog-outgoing-set go)) '() (cadr (cog-outgoing-set go)))]
-            [pairs (find (lambda (x) (equal? x (cons (cog-name gene-a) (cog-name gene-b)))) (biogrid-pairs))]
             [crna  (if (= 0 (cog-arity rna)) '() (gar rna))]
             [ncrna (if (= 0 (cog-arity rna)) '() (gadr rna))]
             [crna-name (cog-name crna)]
             [ncrna-name (cog-name ncrna)]
+            [prot-name  (cog-name prot)]
           )
-          (if (not pairs)
-            (biogrid-pairs (append (biogrid-pairs) (list (cons (cog-name gene-a) (cog-name gene-b)))))
-          )
+
           ;; Neither gene has been done yet.
           (cond
               ((and (not already-done-a) (not already-done-b))
@@ -697,8 +695,9 @@ translates to."
                        go-cross-annotation
                        rna-cross-annotation)
                 )))
+
               ;;; Both of the genes have been done.
-              (else (if pairs (ListLink) (ListLink interaction)))
+              (else (if already-done-pair (ListLink) (ListLink interaction)))
           )
       )
    )

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -580,6 +580,10 @@ translates to."
   `prot` is either (NumberNode 0) or (NumberNode 1)
       which is used to indicate whether or not protein interactions
       should be computed.
+
+  `rna` may be either an empty ListLink, or may have one, or two
+      ConceptNodes in it. If it has two, then first one is the coding RNA,
+      and the second one is the non-coding RNA.
 "
 	(if
 		(or (equal? (cog-type gene-a) 'VariableNode)
@@ -603,13 +607,13 @@ translates to."
                      output "inferred_interaction"))
                 (build-interaction gene-a gene-b output "interacts_with"))]
 
-            [namespace (if (= 0 (cog-arity go)) '() (gar go))]
-            [parent    (if (= 0 (cog-arity go)) '() (gadr go))]
+            [namespace (gar go)]
+            [parent    (gdr go)]
 
-            [crna      (if (= 0 (cog-arity rna)) '() (gar rna))]
-            [ncrna     (if (= 0 (cog-arity rna)) '() (gadr rna))]
-            [crna-name (cog-name crna)]
-            [ncrna-name (cog-name ncrna)]
+            [crna      (gar rna)]   ; coding RNA
+            [ncrna     (gdr rna)]   ; non-coding RNA
+            [crna-name  (if (null? crna)  "" (cog-name crna))]
+            [ncrna-name (if (null? ncrna) "" (cog-name ncrna))]
           )
 
           ;; Neither gene has been done yet.

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -112,7 +112,7 @@ atomspace."
 
 (define-public (annotate-genes genes-list file-name request)
   (parameterize ((biogrid-genes (make-atom-set))
-                 (biogrid-pairs '())
+                 (biogrid-pairs (make-atom-set))
                  (biogrid-pairs-pathway '()))
     (let* ([fns (parse-request genes-list file-name request)]
            [result (par-map (lambda (x) (x)) fns)] )

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -111,7 +111,7 @@ atomspace."
 )
 
 (define-public (annotate-genes genes-list file-name request)
-  (parameterize ((biogrid-genes '())
+  (parameterize ((biogrid-genes (make-atom-set))
                  (biogrid-pairs '())
                  (biogrid-pairs-pathway '()))
     (let* ([fns (parse-request genes-list file-name request)]

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -24,7 +24,7 @@
 	#:use-module (opencog)
 	#:use-module (opencog exec)
 	#:use-module (opencog bioscience)
-  #:use-module (annotation graph)
+	#:use-module (annotation graph)
 	#:use-module (ice-9 optargs)
 ;	#:use-module (rnrs base)
 	#:use-module (rnrs exceptions)
@@ -38,7 +38,7 @@
 
 ;;Define the parameters needed for GGI
 (define-public biogrid-genes (make-parameter (make-atom-set)))
-(define-public biogrid-pairs (make-parameter '()))
+(define-public biogrid-pairs (make-parameter (make-atom-set)))
 (define-public biogrid-pairs-pathway (make-parameter '()))
 
 (define (get-name atom)

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -37,7 +37,7 @@
 )
 
 ;;Define the parameters needed for GGI
-(define-public biogrid-genes (make-parameter '()))
+(define-public biogrid-genes (make-parameter (make-atom-set)))
 (define-public biogrid-pairs (make-parameter '()))
 (define-public biogrid-pairs-pathway (make-parameter '()))
 


### PR DESCRIPTION
Improve overall performance, as described in issue #106.
Per earlier measurements, `generate-result` should run 6x or 7x faster
after this patch, and `find-output-interactors` should run more than 2x faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozi-ai/annotation-scheme/133)
<!-- Reviewable:end -->
