### PR TITLE
Bug-fix incorrect coding-protein info-dump.

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -659,7 +659,7 @@ translates to."
                             (Evaluation (Predicate "expresses") (List gene-b coding-prot-b))
                             (node-info gene-b)
                             (node-info coding-prot-b)
-                            (locate-node coding-prot-a)
+                            (locate-node coding-prot-b)
                             go-cross-annotation
                             rna-cross-annotation
                           )


### PR DESCRIPTION
Fix what appears to be a very old cut-n-paste bug, where the wrong
coding protien was being discovered.  This bug was already in the
December 2019 version of the code; I spotted it recently during
updates.