### PR TITLE
Remove a link to a file that does not exist.

### DIFF
--- a/build-aux/test-driver
+++ b/build-aux/test-driver
@@ -1,1 +1,0 @@
-/usr/share/automake-1.15/test-driver


### PR DESCRIPTION
On my system, this points at /usr/share/automake-1.15/test-driver
but there is no such file.  As such, whatever this was meant to do,
it cannot possibly work...