### PR TITLE
Simplify the structure of find-rna

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -808,7 +808,7 @@ translates to."
 (define-public (find-rna gene coding noncoding protein)
 	(map
 		(lambda (transcribe)
-			(filterbytype gene transcribe (Concept coding) (Concept noncoding) (Number protein)))
+			(filterbytype gene transcribe coding noncoding (Number protein)))
 
 		(run-query (Get
 			(TypedVariable (Variable "$a") (Type 'MoleculeNode))
@@ -817,14 +817,10 @@ translates to."
 
 (define-public (filterbytype gene rna cod ncod prot)
   (ListLink 
-   (if (and (string=? (cog-name cod) "True")
+   (if (and (string=? cod "True")
             (string-prefix? "ENST" (cog-name rna)))
        (list
-        (EvaluationLink
-         (PredicateNode "transcribed_to")
-         (ListLink
-          gene
-          rna))
+        (Evaluation (Predicate "transcribed_to") (List gene rna))
         (node-info rna)
         (if (= (string->number (cog-name prot)) 1)
             (list
@@ -836,14 +832,10 @@ translates to."
              (node-info (car (find-translates rna))))
             '()))
        '())
-   (if (and (string=? (cog-name ncod) "True")
+   (if (and (string=? ncod "True")
             (not (string-prefix? "ENST" (cog-name rna))))
        (list
-        (EvaluationLink
-         (PredicateNode "transcribed_to")
-         (ListLink
-          gene
-          rna))
+        (Evaluation (Predicate "transcribed_to") (List gene rna))
         (node-info rna))
        '())))
 

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -806,10 +806,11 @@ translates to."
 ;; ------------------------------------------------------
 ;; Finds coding and non coding RNA for a given gene
 (define-public (find-rna gene coding noncoding protein)
+	(define do-coding (string=? coding "True"))
+	(define do-noncoding (string=? noncoding "True"))
 	(map
 		(lambda (transcribe)
-			(filterbytype gene transcribe coding noncoding (Number protein)))
-
+			(filterbytype gene transcribe do-coding do-noncoding (Number protein)))
 		(run-query (Get
 			(TypedVariable (Variable "$a") (Type 'MoleculeNode))
 			(Evaluation (Predicate "transcribed_to") (List gene (Variable "$a"))))))
@@ -817,8 +818,7 @@ translates to."
 
 (define-public (filterbytype gene rna cod ncod prot)
   (ListLink 
-   (if (and (string=? cod "True")
-            (string-prefix? "ENST" (cog-name rna)))
+   (if (and cod (string-prefix? "ENST" (cog-name rna)))
        (list
         (Evaluation (Predicate "transcribed_to") (List gene rna))
         (node-info rna)
@@ -832,8 +832,7 @@ translates to."
              (node-info (car (find-translates rna))))
             '()))
        '())
-   (if (and (string=? ncod "True")
-            (not (string-prefix? "ENST" (cog-name rna))))
+   (if (and ncod (not (string-prefix? "ENST" (cog-name rna))))
        (list
         (Evaluation (Predicate "transcribed_to") (List gene rna))
         (node-info rna))

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -806,25 +806,13 @@ translates to."
 ;; ------------------------------------------------------
 ;; Finds coding and non coding RNA for a given gene
 (define-public (find-rna gene coding noncoding protein)
-  (run-query (BindLink
-    (TypedVariable (Variable "$a") (TypeNode 'MoleculeNode))
-      (EvaluationLink
-        (PredicateNode "transcribed_to")
-        (ListLink
-          gene
-          (VariableNode "$a")
-        )
-      )
-    (ExecutionOutputLink
-      (GroundedSchemaNode "scm: filterbytype")
-        (ListLink 
-          gene
-          (VariableNode "$a")
-          (Concept coding)
-          (Concept noncoding)
-          (Number protein))
-    )
-))
+	(map
+		(lambda (transcribe)
+			(filterbytype gene transcribe (Concept coding) (Concept noncoding) (Number protein)))
+
+		(run-query (Get
+			(TypedVariable (Variable "$a") (Type 'MoleculeNode))
+			(Evaluation (Predicate "transcribed_to") (List gene (Variable "$a"))))))
 )
 
 (define-public (filterbytype gene rna cod ncod prot)


### PR DESCRIPTION
There is no need to encode boolean flags as Atoms.  This removes some
overhead, and simplifies the code.

This pull req will also allow the search results to be cached (in a later pull req)