### PR TITLE
Cache find-mol

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -385,8 +385,8 @@ translates to."
 " Finds molecules (proteins or chebi's) in a pathway"
 	(filter-map
 		(lambda (mol)
-			(if (string-contains (cog-name mol) identifier))
-				(add-mol-info mol path) #f)
+			(if (string-contains (cog-name mol) identifier)
+				(add-mol-info mol path) #f))
 		(run-query (Get
 			(TypedVariable (Variable "$a") (Type 'MoleculeNode))
 			(Member (Variable "$a") path))))

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -381,29 +381,26 @@ translates to."
   )
 )
 
+(define-public filter-atoms
+  (lambda (atom identifier)
+    (if (string-contains (cog-name atom) (cog-name identifier))
+        (cog-new-stv 1 1)
+        (cog-new-stv 0 1)
+    )
+  )
+)
+
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"
-  (run-query (BindLink
-    (TypedVariable (Variable "$a") (TypeNode 'MoleculeNode))
-    (AndLink
-      (EvaluationLink
-        (GroundedPredicateNode "scm: filter-atoms")
-        (ListLink
-          (VariableNode "$a")
-          (ConceptNode identifier)
-        )
-      )
-       (MemberLink
-       (VariableNode "$a")
-       path)
-    )
-    (ExecutionOutputLink
-      (GroundedSchemaNode "scm: add-mol-info")
-      (ListLink
-        (VariableNode "$a")
-        path
-      )
-    )))
+	(map
+		(lambda (mol) (add-mol-info mol path))
+		(run-query (Get
+			(TypedVariable (Variable "$a") (Type 'MoleculeNode))
+			(And
+				(Evaluation
+					(GroundedPredicate "scm: filter-atoms")
+					(List (Variable "$a") (Concept identifier)))
+				(Member (Variable "$a") path)))))
 )
 
 ;; Find coding Gene for a given protein
@@ -427,15 +424,6 @@ translates to."
     )
   )
 )))
-
-(define-public filter-atoms
-  (lambda (atom identifier)
-    (if (string-contains (cog-name atom) (cog-name identifier))
-        (cog-new-stv 1 1)
-        (cog-new-stv 0 0) 
-    )
-  )
-) 
 
 
 ;; Finds genes interacting with a given gene

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -390,13 +390,16 @@ translates to."
 		(TypedVariable (Variable "$a") (Type 'MoleculeNode))
 		(Member (Variable "$a") path))))
 
+(define cache-get-mol
+	(make-afunc-cache do-get-mol))
+
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"
 	(filter-map
 		(lambda (mol)
 			(if (string-contains (cog-name mol) identifier)
 				(add-mol-info mol path) #f))
-		(do-get-mol path))
+		(cache-get-mol path))
 )
 
 ;; Find coding Gene for a given protein

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -381,22 +381,15 @@ translates to."
   )
 )
 
-(define-public (filter-atoms atom identifier)
-	(if (string-contains (cog-name atom) (cog-name identifier))
-		(cog-new-stv 1 1) (cog-new-stv 0 1)))
-
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"
-	(define cid (Concept identifier))
-	(map
-		(lambda (mol) (add-mol-info mol path))
+	(filter-map
+		(lambda (mol)
+			(if (string-contains (cog-name mol) identifier))
+				(add-mol-info mol path) #f)
 		(run-query (Get
 			(TypedVariable (Variable "$a") (Type 'MoleculeNode))
-			(And
-				(Evaluation
-					(GroundedPredicate "scm: filter-atoms")
-					(List (Variable "$a") cid))
-				(Member (Variable "$a") path)))))
+			(Member (Variable "$a") path))))
 )
 
 ;; Find coding Gene for a given protein

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -196,6 +196,10 @@ in the specified namespaces."
       go
       (VariableNode "$def"))))))
 
+(define-public (filter-atoms atom identifier)
+	(if (string-contains (cog-name atom) (cog-name identifier))
+		(cog-new-stv 1 1) (cog-new-stv 0 1)))
+
 (define-public (find-pathway-member gene db)
   (run-query (BindLink
       (TypedVariable (Variable "$a") (TypeNode 'ConceptNode))

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -356,6 +356,31 @@ translates to."
 		(cog-incoming-by-type pw 'InheritanceLink)))
 
 
+(define (add-mol-info mol path)
+  (if (string-contains (cog-name path) "R-HSA")
+    (ListLink
+      (MemberLink mol path)
+      (if (string-contains (cog-name mol) "Uniprot")
+        (find-coding-gene mol)
+        '()
+        )
+      (node-info mol)
+      (ListLink
+        (add-loc (MemberLink mol path))
+      )
+    )
+    (ListLink
+      (MemberLink mol path)
+      (if (string-contains (cog-name mol) "Uniprot")
+        (find-coding-gene mol)
+        '()
+      )
+      (node-info mol)
+      (ListLink (locate-node mol))
+    )
+  )
+)
+
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"
   (run-query (BindLink
@@ -402,32 +427,6 @@ translates to."
     )
   )
 )))
-
-(define-public add-mol-info
-  (lambda (mol path)
-  (if (string-contains (cog-name path) "R-HSA")
-    (ListLink
-      (MemberLink mol path)
-      (if (string-contains (cog-name mol) "Uniprot")
-        (find-coding-gene mol)
-        '()
-        )
-      (node-info mol)
-      (ListLink 
-        (add-loc (MemberLink mol path))
-      )
-    )
-    (ListLink
-      (MemberLink mol path)
-      (if (string-contains (cog-name mol) "Uniprot")
-        (find-coding-gene mol)
-        '()
-      )
-      (node-info mol)
-      (ListLink (locate-node mol))
-    )
-  )
-))
 
 (define-public filter-atoms
   (lambda (atom identifier)

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -385,15 +385,18 @@ translates to."
   )
 )
 
+(define (do-get-mol path)
+	(run-query (Get
+		(TypedVariable (Variable "$a") (Type 'MoleculeNode))
+		(Member (Variable "$a") path))))
+
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"
 	(filter-map
 		(lambda (mol)
 			(if (string-contains (cog-name mol) identifier)
 				(add-mol-info mol path) #f))
-		(run-query (Get
-			(TypedVariable (Variable "$a") (Type 'MoleculeNode))
-			(Member (Variable "$a") path))))
+		(do-get-mol path))
 )
 
 ;; Find coding Gene for a given protein

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -381,17 +381,13 @@ translates to."
   )
 )
 
-(define-public filter-atoms
-  (lambda (atom identifier)
-    (if (string-contains (cog-name atom) (cog-name identifier))
-        (cog-new-stv 1 1)
-        (cog-new-stv 0 1)
-    )
-  )
-)
+(define-public (filter-atoms atom identifier)
+	(if (string-contains (cog-name atom) (cog-name identifier))
+		(cog-new-stv 1 1) (cog-new-stv 0 1)))
 
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"
+	(define cid (Concept identifier))
 	(map
 		(lambda (mol) (add-mol-info mol path))
 		(run-query (Get
@@ -399,7 +395,7 @@ translates to."
 			(And
 				(Evaluation
 					(GroundedPredicate "scm: filter-atoms")
-					(List (Variable "$a") (Concept identifier)))
+					(List (Variable "$a") cid))
 				(Member (Variable "$a") path)))))
 )
 


### PR DESCRIPTION
This provides a 1.6x perf improvement in `find-mol` performance, dropping run-time from 165 seconds to 100 seconds, as documented in https://github.com/MOZI-AI/annotation-scheme/issues/141#issuecomment-595892834 