### PR TITLE
Cache find-coding-gene

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -381,27 +381,18 @@ translates to."
     )))
 )
 
-;; Find coding Gene for a given protein
-(define-public find-coding-gene
-  (lambda (protein)
-  (run-query (BindLink
-    (TypedVariable (Variable "$g") (TypeNode 'GeneNode))
-    (EvaluationLink
-      (PredicateNode "expresses")
-      (ListLink
-        (VariableNode "$g")
-        protein
-      )
-    )
-    (EvaluationLink
-      (PredicateNode "expresses")
-      (ListLink
-        (VariableNode "$g")
-        protein
-      )
-    )
-  )
-)))
+(define-public (find-coding-gene protein)
+"
+  Find coding Gene for a given protein
+"
+	(define evlnk
+		(Evaluation (Predicate "expresses")
+			(List (Variable "$g") protein)))
+
+	(run-query (Bind
+		(TypedVariable (Variable "$g") (Type 'GeneNode))
+		evlnk evlnk))
+)
 
 (define-public add-mol-info
   (lambda (mol path)

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -381,7 +381,9 @@ translates to."
     )))
 )
 
-(define-public (find-coding-gene protein)
+; ------------------------------------
+
+(define (do-find-coding-gene protein)
 "
   Find coding Gene for a given protein
 "
@@ -393,6 +395,11 @@ translates to."
 		(TypedVariable (Variable "$g") (Type 'GeneNode))
 		evlnk evlnk))
 )
+
+(define-public find-coding-gene
+	(make-afunc-cache do-find-coding-gene))
+
+; ------------------------------------
 
 (define-public add-mol-info
   (lambda (mol path)


### PR DESCRIPTION
This provides a 10x perf improvement in `find-coding-gene` performance, dropping run-time from 42 seconds to 4 seconds, as documented in https://github.com/MOZI-AI/annotation-scheme/issues/141#issuecomment-595946633  This is mostly due to a cache-miss ratio of 8517/177359 = 4.8% i.e. the other 95% of the time, its a cache hit, and so the previous query results are reused.