### PR TITLE
Cache find pathway

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -230,7 +230,7 @@ in the specified namespaces."
 
 ; --------------------------------------------------------
 
-(define-public (add-pathway-genes pathway gene namespace-list num-parents
+(define (add-pathway-genes pathway gene namespace-list num-parents
                 coding-rna non-coding-rna do-protein)
 
 	(define no-rna (or (null? coding-rna) (null? non-coding-rna)))
@@ -252,6 +252,18 @@ in the specified namespaces."
 					(List (Concept "rna-annotation") rnaresult
 						(List (Concept "gene-pathway-annotation")))))))
 )
+
+(define (get-pathway-genes pathway)
+	(run-query
+		(Bind
+			(VariableList
+				(TypedVariable (Variable "$p") (Type 'MoleculeNode))
+				(TypedVariable (Variable "$g") (Type 'GeneNode)))
+			(And
+				(Member (Variable "$p") pathway)
+				(Evaluation (Predicate "expresses")
+					(List (Variable "$g") (Variable "$p"))))
+			(Variable "$g"))))
 
 (define-public (find-pathway-genes pathway go rna do-protein)
 "
@@ -276,16 +288,7 @@ in the specified namespaces."
 		(lambda (gene)
 			(add-pathway-genes pathway gene namespace-list num-parents
 				coding-rna non-coding-rna do-protien))
-		(run-query
-			(Bind
-				(VariableList
-					(TypedVariable (Variable "$p") (Type 'MoleculeNode))
-					(TypedVariable (Variable "$g") (Type 'GeneNode)))
-				(And
-					(Member (Variable "$p") pathway)
-					(Evaluation (Predicate "expresses")
-						(List (Variable "$g") (Variable "$p"))))
-				(Variable "$g"))))
+		(get-pathway-genes pathway))
 )
 
 ; --------------------------------------------------------

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -253,7 +253,7 @@ in the specified namespaces."
 						(List (Concept "gene-pathway-annotation")))))))
 )
 
-(define (get-pathway-genes pathway)
+(define (do-get-pathway-genes pathway)
 	(run-query
 		(Bind
 			(VariableList
@@ -265,6 +265,8 @@ in the specified namespaces."
 					(List (Variable "$g") (Variable "$p"))))
 			(Variable "$g"))))
 
+(define get-pathway-genes (make-afunc-cache do-get-pathway-genes))
+
 (define-public (find-pathway-genes pathway go rna do-protein)
 "
   Find genes which code the proteins in a given pathway.  Perform
@@ -273,6 +275,7 @@ in the specified namespaces."
   RNA transcribes; if prot?, include the proteins in which the RNA
   translates to.
 "
+
 	(define namespaces (gar go))
 	(define parent (gdr go))
 	(define namespace-list

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -270,28 +270,21 @@ cross-annotation: if go, annotate each member genes of a pathway for
 its GO terms; if rna, annotate each member genes of a pathway for its
 RNA transcribes; if prot?, include the proteins in which the RNA
 translates to."
-  (run-query
-   (BindLink
-    (VariableList
-     (TypedVariable (VariableNode "$p") (Type 'MoleculeNode))
-     (TypedVariable (VariableNode "$g") (Type 'GeneNode)))
-    (AndLink
-     (MemberLink
-      (VariableNode "$p")
-      pathway)
-     (EvaluationLink
-      (PredicateNode "expresses")
-      (ListLink
-       (VariableNode "$g")
-       (VariableNode "$p") )))
-    (ExecutionOutputLink
-     (GroundedSchemaNode "scm: add-pathway-genes")
-     (ListLink
-      pathway
-      (VariableNode "$g")
-      go
-      rna
-      (ConceptNode (if prot? "True" "False")))))))
+	(map
+		(lambda (gene)
+			(add-pathway-genes pathway gene go rna
+				(ConceptNode (if prot? "True" "False"))))
+		(run-query
+			(Bind
+				(VariableList
+					(TypedVariable (Variable "$p") (Type 'MoleculeNode))
+					(TypedVariable (Variable "$g") (Type 'GeneNode)))
+				(And
+					(Member (Variable "$p") pathway)
+					(Evaluation (Predicate "expresses")
+						(List (Variable "$g") (Variable "$p"))))
+				(Variable "$g"))))
+)
 
 ; --------------------------------------------------------
 

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -286,7 +286,7 @@ in the specified namespaces."
 	(map
 		(lambda (gene)
 			(add-pathway-genes pathway gene namespace-list num-parents
-				coding-rna non-coding-rna do-protien))
+				coding-rna non-coding-rna do-protein))
 		(get-pathway-genes pathway))
 )
 

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -267,26 +267,22 @@ in the specified namespaces."
 
 (define get-pathway-genes (make-afunc-cache do-get-pathway-genes))
 
-(define-public (find-pathway-genes pathway go rna do-protein)
+(define-public (find-pathway-genes pathway namespace-list num-parents
+                  coding-rna non-coding-rna do-protein)
 "
   Find genes which code the proteins in a given pathway.  Perform
-  cross-annotation: if go, annotate each member genes of a pathway for
-  its GO terms; if rna, annotate each member genes of a pathway for its
-  RNA transcribes; if prot?, include the proteins in which the RNA
-  translates to.
+  cross-annotation. If there is a list of namespaces, then annotate
+  each member genes of a pathway for its GO terms. If both
+  rna flags are true, annotate each member genes of a pathway for its
+  RNA transcribes. If do-protein is true, include the proteins in which the
+  RNA translates to.
+
+  'namespace-list' should be a list of string names of namespaces.
+  'num-parents' should be a non-negative integer.
+  'coding-rna' should be either the empty list, or the string "True"
+  'non-coding-rna' should be either the empty list, or the string "True"
+  'do-protein' should be either #f or #t.
 "
-
-	(define namespaces (gar go))
-	(define parent (gdr go))
-	(define namespace-list
-		(string-split (cog-name namespace) #\space))
-	(define num-parents (string->number (cog-name parent)))
-
-	(define crna (gar rna))
-	(define ncrna (gdr rna))
-	(define coding-rna (cog-name crna))
-	(define non-coding-rna (cog-name ncrna))
-
 	(map
 		(lambda (gene)
 			(add-pathway-genes pathway gene namespace-list num-parents

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -230,7 +230,7 @@ in the specified namespaces."
 
 ; --------------------------------------------------------
 
-(define-public (add-pathway-genes pathway gene go rna prot)
+(define-public (add-pathway-genes pathway gene go rna do-protein)
   (let ((go-set (cog-outgoing-set go))
         (rna-set (cog-outgoing-set rna)))
     (if (and (null? go-set) (null? rna-set))
@@ -252,8 +252,7 @@ in the specified namespaces."
            (_ '()))
          (match rna-set
            ((crna ncrna . _)
-            (let* ([do-protein (string=? (cog-name prot) "True")]
-                   [rnaresult (find-rna gene
+            (let* ([rnaresult (find-rna gene
                                         (cog-name crna)
                                         (cog-name ncrna)
                                         do-protein)])
@@ -264,7 +263,7 @@ in the specified namespaces."
            (_ '()))))))
 
 
-(define-public (find-pathway-genes pathway go rna prot?)
+(define-public (find-pathway-genes pathway go rna do-protein)
   "Find genes which code the proteins in a given pathway.  Perform
 cross-annotation: if go, annotate each member genes of a pathway for
 its GO terms; if rna, annotate each member genes of a pathway for its
@@ -272,8 +271,7 @@ RNA transcribes; if prot?, include the proteins in which the RNA
 translates to."
 	(map
 		(lambda (gene)
-			(add-pathway-genes pathway gene go rna
-				(ConceptNode (if prot? "True" "False"))))
+			(add-pathway-genes pathway gene go rna do-protien))
 		(run-query
 			(Bind
 				(VariableList

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -228,34 +228,7 @@ in the specified namespaces."
        (node-info pathway))
       #f))
 
-(define-public (find-pathway-genes pathway go rna prot?)
-  "Find genes which code the proteins in a given pathway.  Perform
-cross-annotation: if go, annotate each member genes of a pathway for
-its GO terms; if rna, annotate each member genes of a pathway for its
-RNA transcribes; if prot?, include the proteins in which the RNA
-translates to."
-  (run-query
-   (BindLink
-    (VariableList 
-     (TypedVariable (VariableNode "$p") (Type 'MoleculeNode))
-     (TypedVariable (VariableNode "$g") (Type 'GeneNode)))
-    (AndLink
-     (MemberLink
-      (VariableNode "$p")
-      pathway)
-     (EvaluationLink
-      (PredicateNode "expresses")
-      (ListLink
-       (VariableNode "$g")
-       (VariableNode "$p") )))
-    (ExecutionOutputLink
-     (GroundedSchemaNode "scm: add-pathway-genes")
-     (ListLink
-      pathway
-      (VariableNode "$g")
-      go
-      rna
-      (ConceptNode (if prot? "True" "False")))))))
+; --------------------------------------------------------
 
 (define-public (add-pathway-genes pathway gene go rna prot)
   (let ((go-set (cog-outgoing-set go))
@@ -289,6 +262,38 @@ translates to."
                   (ListLink (ConceptNode "rna-annotation") rnaresult
                             (ListLink (ConceptNode "gene-pathway-annotation"))))))
            (_ '()))))))
+
+
+(define-public (find-pathway-genes pathway go rna prot?)
+  "Find genes which code the proteins in a given pathway.  Perform
+cross-annotation: if go, annotate each member genes of a pathway for
+its GO terms; if rna, annotate each member genes of a pathway for its
+RNA transcribes; if prot?, include the proteins in which the RNA
+translates to."
+  (run-query
+   (BindLink
+    (VariableList
+     (TypedVariable (VariableNode "$p") (Type 'MoleculeNode))
+     (TypedVariable (VariableNode "$g") (Type 'GeneNode)))
+    (AndLink
+     (MemberLink
+      (VariableNode "$p")
+      pathway)
+     (EvaluationLink
+      (PredicateNode "expresses")
+      (ListLink
+       (VariableNode "$g")
+       (VariableNode "$p") )))
+    (ExecutionOutputLink
+     (GroundedSchemaNode "scm: add-pathway-genes")
+     (ListLink
+      pathway
+      (VariableNode "$g")
+      go
+      rna
+      (ConceptNode (if prot? "True" "False")))))))
+
+; --------------------------------------------------------
 
 (define-public (find-protein gene option)
   "Find the proteins a gene expresses."

--- a/annotation/gene-pathway.scm
+++ b/annotation/gene-pathway.scm
@@ -66,7 +66,7 @@
     (write-to-file res file-name "gene-pathway")
     res))
 
-(define (smpdb gene prot? sm? go biogrid namespaces num-parents coding-rna non-coding-rna)
+(define (smpdb gene prot? sm? namespaces num-parents biogrid coding-rna non-coding-rna)
 "
   From SMPDB
 "

--- a/annotation/gene-pathway.scm
+++ b/annotation/gene-pathway.scm
@@ -78,7 +78,7 @@
 	(define namespaces (gar go))
 	(define parent (gdr go))
 	(define namespace-list
-		(string-split (cog-name namespace) #\space))
+		(string-split (cog-name namespaces) #\space))
 	(define num-parents (string->number (cog-name parent)))
 
 	(define crna (gar rna))
@@ -116,7 +116,7 @@
 	(define namespaces (gar go))
 	(define parent (gdr go))
 	(define namespace-list
-		(string-split (cog-name namespace) #\space))
+		(string-split (cog-name namespaces) #\space))
 	(define num-parents (string->number (cog-name parent)))
 
 	(define crna (gar rna))

--- a/annotation/gene-pathway.scm
+++ b/annotation/gene-pathway.scm
@@ -71,14 +71,28 @@
     (write-to-file res file-name "gene-pathway")
     res))
 
-;; From SMPDB
 (define (smpdb gene prot? sm? go biogrid rna)
+"
+  From SMPDB
+"
+	(define namespaces (gar go))
+	(define parent (gdr go))
+	(define namespace-list
+		(string-split (cog-name namespace) #\space))
+	(define num-parents (string->number (cog-name parent)))
+
+	(define crna (gar rna))
+	(define ncrna (gdr rna))
+	(define coding-rna (cog-name crna))
+	(define non-coding-rna (cog-name ncrna))
+
   (let* ([pw (find-pathway-member (GeneNode gene) "SMP")]
          [ls (append-map (lambda (path)
                            (let ([node (cog-outgoing-atom (cog-outgoing-atom path 0) 1)])
                              (append
                               (if sm? (find-mol node "ChEBI") '())
-                              (find-pathway-genes node go rna prot?)
+                              (find-pathway-genes node namespace-list num-parents
+                                      coding-rna non-coding-rna prot?)
                               (if prot?
                                   (let ([prots (find-mol node "Uniprot")])
                                     (if (null? prots)
@@ -95,15 +109,29 @@
             (if prot? (find-protein (GeneNode gene) 0) '())
             ls)))
 
-;; From reactome
 (define (reactome gene prot? sm? pwlst go biogrid rna)
+"
+  From reactome
+"
+	(define namespaces (gar go))
+	(define parent (gdr go))
+	(define namespace-list
+		(string-split (cog-name namespace) #\space))
+	(define num-parents (string->number (cog-name parent)))
+
+	(define crna (gar rna))
+	(define ncrna (gdr rna))
+	(define coding-rna (cog-name crna))
+	(define non-coding-rna (cog-name ncrna))
+
   (let* ([pw (find-pathway-member (GeneNode gene) "R-HSA")]
          [ls (append-map (lambda (path)
                            (let ([node (cog-outgoing-atom (cog-outgoing-atom path 0) 1)])
                              (set! pwlst (append pwlst (list node)))
 
                              (append
-                              (find-pathway-genes node go rna prot?)
+                              (find-pathway-genes node namespace-list num-parents
+                                      coding-rna non-coding-rna prot?)
                               (if prot?
                                   (let ([prots (find-mol node "Uniprot")])
                                     (if (null? prots)


### PR DESCRIPTION
Unwrap the `GroundedSchema` and replace by `srfi-1 map`.  This allows simplification of the overall structure, but avoiding the need to wrap and unwrap boolean arguments as Atoms. This is similar to #149 and together with that, will allow find-rna arguments to just  be #t and #f 