### PR TITLE
Pull string compare out of the inner loop.

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -769,9 +769,12 @@ in the specified namespaces."
 (define cache-get-rna
 	(make-afunc-cache do-get-rna))
 
-(define-public (find-rna gene coding noncoding do-protein)
-	(define do-coding (string=? coding "True"))
-	(define do-noncoding (string=? noncoding "True"))
+(define-public (find-rna gene do-coding do-noncoding do-protein)
+"
+  find-rna GENE do-coding do-noncoding do-protein
+  GENE should be a GeneNode
+  do-coding do-noncoding do-protein should be #t or #f
+"
 	(map
 		(lambda (transcribe)
 			(filterbytype gene transcribe do-coding do-noncoding do-protein))

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -239,9 +239,9 @@ in the specified namespaces."
 ; --------------------------------------------------------
 
 (define (add-pathway-genes pathway gene namespace-list num-parents
-                coding-rna non-coding-rna do-protein)
+                do-coding-rna do-non-coding-rna do-protein)
 
-	(define no-rna (or (null? coding-rna) (null? non-coding-rna)))
+	(define no-rna (not (or do-coding-rna do-non-coding-rna)))
 	(define no-ns (and (null? namespace-list) (= 0 num-parents)))
 
 	(List
@@ -255,7 +255,7 @@ in the specified namespaces."
 				(List (Concept "gene-pathway-annotation"))))
 		(if no-rna '()
 			(let* ([rnaresult
-						(find-rna gene coding-rna non-coding-rna do-protein)])
+						(find-rna gene do-coding-rna do-non-coding-rna do-protein)])
 				(if (null? rnaresult) '()
 					(List (Concept "rna-annotation") rnaresult
 						(List (Concept "gene-pathway-annotation")))))))

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -287,8 +287,8 @@ in the specified namespaces."
 
   'namespace-list' should be a list of string names of namespaces.
   'num-parents' should be a non-negative integer.
-  'coding-rna' should be either the empty list, or the string "True"
-  'non-coding-rna' should be either the empty list, or the string "True"
+  'coding-rna' should be either #f or #t.
+  'non-coding-rna' should be either #f or #t.
   'do-protein' should be either #f or #t.
 "
 	(map
@@ -556,8 +556,8 @@ in the specified namespaces."
 
   `num-parents` should be a number.
 
-  `coding-rna` should be either null or the string "True".
-  `non-coding-rna` should be either null or the string "True".
+  `coding-rna` should be either #f or #t.
+  `non-coding-rna` should be either #f or #t.
 "
 	(if
 		(or (equal? (cog-type gene-a) 'VariableNode)

--- a/annotation/gene-pathway.scm
+++ b/annotation/gene-pathway.scm
@@ -43,6 +43,10 @@
                                   (biogrid 1)
                                   coding
                                   noncoding)
+
+  (define do-coding (string=? coding "True"))
+  (define do-noncoding (string=? noncoding "True"))
+
   (let* ([pwlst '()]
          [prot? (string=? include_prot "True")]
          [sm? (string=? include_sm "True")]
@@ -53,9 +57,9 @@
                          (node-info (GeneNode gene))
                          (append-map (match-lambda
                                        ("smpdb"
-                                        (smpdb gene prot? sm? namespace parents biogrid coding noncoding))
+                                        (smpdb gene prot? sm? namespace parents biogrid do-coding do-noncoding))
                                        ("reactome"
-                                        (match (reactome gene prot? sm? pwlst namespace parents biogrid coding noncoding)
+                                        (match (reactome gene prot? sm? pwlst namespace parents biogrid do-coding do-noncoding)
                                           ((first . rest)
                                            (set! pwlst (append pwlst rest))
                                            first))))

--- a/annotation/rna.scm
+++ b/annotation/rna.scm
@@ -39,20 +39,17 @@
   non-coding -> when True includes the non-coding RNA's
   protein -> scheme number, 0 or 1.
 "
-  ; Convert string flags to scheme booleans
-  (define do-coding (string=? coding "True"))
-  (define do-noncoding (string=? noncoding "True"))
-  (define do-protein (= protein 1))
+	; Convert string flags to scheme booleans
+	(define do-coding (string=? coding "True"))
+	(define do-noncoding (string=? noncoding "True"))
+	(define do-protein (= protein 1))
 
-  (let ((rna
-    (map (lambda (gene)
-      (find-rna (GeneNode gene) do-coding do-noncoding do-protein))
-      gene-list)))
-    (let (
-    	[res (ListLink (ConceptNode "rna-annotation") rna)]
-  		)
-    	(write-to-file res file-name "mainRNA")
-		res
-  	 )
-  )
+	(let ((rna (map (lambda (gene)
+				(find-rna (GeneNode gene) do-coding do-noncoding do-protein))
+				gene-list)))
+		(let ([res (ListLink (ConceptNode "rna-annotation") rna)])
+			(write-to-file res file-name "mainRNA")
+			res
+		)
+	)
 )

--- a/annotation/rna.scm
+++ b/annotation/rna.scm
@@ -27,18 +27,24 @@
 	#:use-module (annotation parser)
 	#:export (include-rna)
 )
- 
+
 (define* (include-rna gene-list file-name #:key (coding "True") (noncoding "True") (protein 1))
-;;; 
-;;; The include-rna function finds coding and non-coding RNA forms of the gene-list. needs 4 arguments to do so.
-;;; file-name -> where to write the output file
-;;; coding -> when True, includes the coding RNA's
-;;; coding -> when True with protein True, includes the coding RNA's and crosponding coding proteins 
-;;; non-coding -> when True includes the non-coding RNA's 
+"
+  The include-rna function finds coding and non-coding RNA forms of
+  the gene-list. Needs 4 arguments:
+  file-name -> where to write the output file
+  coding -> when True, includes the coding RNA's
+  coding -> when True with protein True, includes the coding RNA's
+            and crosponding coding proteins
+  non-coding -> when True includes the non-coding RNA's
+"
+  ; Convert string flags to scheme booleans
+  (define do-coding (string=? coding "True"))
+  (define do-noncoding (string=? noncoding "True"))
 
   (let* ((rna
     (map (lambda (gene)
-      (find-rna (GeneNode gene) coding noncoding protein)
+      (find-rna (GeneNode gene) do-coding do-noncoding protein)
     )gene-list)
     ))
     (let (

--- a/annotation/rna.scm
+++ b/annotation/rna.scm
@@ -35,23 +35,24 @@
   file-name -> where to write the output file
   coding -> when True, includes the coding RNA's
   coding -> when True with protein True, includes the coding RNA's
-            and crosponding coding proteins
+            and corresponding coding proteins.
   non-coding -> when True includes the non-coding RNA's
+  protein -> scheme number, 0 or 1.
 "
   ; Convert string flags to scheme booleans
   (define do-coding (string=? coding "True"))
   (define do-noncoding (string=? noncoding "True"))
+  (define do-protein (= protein 1))
 
-  (let* ((rna
+  (let ((rna
     (map (lambda (gene)
-      (find-rna (GeneNode gene) do-coding do-noncoding protein)
-    )gene-list)
-    ))
+      (find-rna (GeneNode gene) do-coding do-noncoding do-protein))
+      gene-list)))
     (let (
     	[res (ListLink (ConceptNode "rna-annotation") rna)]
   		)
     	(write-to-file res file-name "mainRNA")
 		res
-  	)
+  	 )
   )
 )


### PR DESCRIPTION
This should save some CPU time, as `find-rna` is called quite often.
This avoids a string compare in the inner loop.