### PR TITLE
Add locks as a fix for issue #144

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -156,7 +156,7 @@ in the specified namespaces."
 
 ; Cache the results; this includes the caching of two distinct
 ; BindLinks/GetLinks: one in `find-GO-ns` and one in `find-go-name`.
-(define go-info (make-afunc-cache do-go-info))
+(define go-info (memoize-function-call do-go-info))
 
 (define (find-GO-ns go)
   "Find parents of a GO term (of given namespace type)."
@@ -273,7 +273,7 @@ in the specified namespaces."
 					(List (Variable "$g") (Variable "$p"))))
 			(Variable "$g"))))
 
-(define get-pathway-genes (make-afunc-cache do-get-pathway-genes))
+(define get-pathway-genes (memoize-function-call do-get-pathway-genes))
 
 (define-public (find-pathway-genes pathway namespace-list num-parents
                   coding-rna non-coding-rna do-protein)
@@ -397,7 +397,7 @@ in the specified namespaces."
 		(Member (Variable "$a") path))))
 
 (define cache-get-mol
-	(make-afunc-cache do-get-mol))
+	(memoize-function-call do-get-mol))
 
 (define-public (find-mol path identifier)
 " Finds molecules (proteins or chebi's) in a pathway"
@@ -424,7 +424,7 @@ in the specified namespaces."
 )
 
 (define-public find-coding-gene
-	(make-afunc-cache do-find-coding-gene))
+	(memoize-function-call do-find-coding-gene))
 
 ; ------------------------------------
 
@@ -513,7 +513,7 @@ in the specified namespaces."
 ;; so any caching at all is a win. In a test of 681 genes, this offers
 ;; a 3x speedup in run time.
 (define-public pathway-gene-interactors
-	(make-afunc-cache do-pathway-gene-interactors))
+	(memoize-function-call do-pathway-gene-interactors))
 
 ;; ---------------------------------
 
@@ -540,7 +540,7 @@ in the specified namespaces."
 ;; and a grand-total 9x speedup for `biogrid-interaction-annotation`.
 ;; Wow.
 (define-public find-protein-form
-	(make-afunc-cache do-find-protein-form))
+	(memoize-function-call do-find-protein-form))
 
 ;; ---------------------------------
 
@@ -752,7 +752,7 @@ in the specified namespaces."
         pub)))
 
 (define cache-find-pubmed-id
-	(make-afunc-cache do-find-pubmed-id))
+	(memoize-function-call do-find-pubmed-id))
 
 ; Memoized version of above, for performance.
 (define-public (find-pubmed-id gene-a gene-b)
@@ -767,7 +767,7 @@ in the specified namespaces."
 		(Evaluation (Predicate "transcribed_to") (List gene (Variable "$a"))))))
 
 (define cache-get-rna
-	(make-afunc-cache do-get-rna))
+	(memoize-function-call do-get-rna))
 
 (define-public (find-rna gene coding noncoding do-protein)
 	(define do-coding (string=? coding "True"))
@@ -804,4 +804,4 @@ in the specified namespaces."
 			(List rna (Variable "$a"))))))
 
 (define-public find-translates
-	(make-afunc-cache do-find-translates))
+	(memoize-function-call do-find-translates))

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -19,10 +19,10 @@
 ;;; <http://www.gnu.org/licenses/>.
 
 (define-module (annotation functions)
-    #:use-module (annotation util)
     #:use-module (opencog)
     #:use-module (opencog exec)
     #:use-module (opencog bioscience)
+    #:use-module (annotation util)
 ;    #:use-module (rnrs base)
     #:use-module (srfi srfi-1)
     #:use-module (ice-9 match)

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -195,6 +195,18 @@
 ; ----------------------------------------------------
 
 (define-public (memoize-function-call FUNC)
+"
+  memoize-function-call - Thread-safe function caching.
+
+  This defines a cache for the function FUNC, assumed to be a function
+  taking a single Stom as input, and returning any output. The cache
+  records (memoizes) the return value returned by FUNC, and if it is
+  called a secnd time, or more, the cached value is returned. This can
+  save large amounts of time if FUNC is expensive.
+
+  This differs from ordinary caching/memoizing utilities as it provides
+  special handling for Atom arguments.
+"
 	(define mtx (make-mutex))
 	(define cache (make-afunc-cache FUNC))
 	(lambda (ATOM) (with-mutex mtx (cache ATOM)))

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -70,7 +70,7 @@
 )
 
 ; Cache results of do-get-node-info for performance.
-(define memoize-node-info (make-afunc-cache do-get-node-info))
+(define memoize-node-info (memoize-function-call do-get-node-info))
 
 (define-public (node-info ENTITY)
 "
@@ -101,7 +101,7 @@
 )
 
 (define find-pathway-name
-	(make-afunc-cache do-find-pathway-name))
+	(memoize-function-call do-find-pathway-name))
 
 (define-public (is-cellular-component? ATOM-LIST)
 "
@@ -165,6 +165,8 @@
       ((single) single)
       ((first second . rest) second))))
 
+; ----------------------------------------------------
+
 (define run-query-mtx (make-mutex))
 (define-public (run-query QUERY)
 "
@@ -189,6 +191,16 @@
 			(run-query QUERY))
 	)
 )
+
+; ----------------------------------------------------
+
+(define-public (memoize-function-call FUNC)
+	(define mtx (make-mutex))
+	(define cache (make-afunc-cache FUNC))
+	(lambda (ATOM) (with-mutex mtx (cache ATOM)))
+)
+
+; ----------------------------------------------------
 
 (define (do-find-name GO-ATOM)
 "
@@ -223,7 +235,7 @@
 
 ; A memoized version of `xfind-name`, improves performance considerably
 ; on repeated searches.
-(define find-name (make-afunc-cache do-find-name))
+(define find-name (memoize-function-call do-find-name))
 
 (define-public (filter-genes input-gene gene-name)
   (if (regexp-match? (string-match (string-append (cog-name input-gene) ".+$") (cog-name gene-name)))
@@ -344,7 +356,7 @@
             (VariableNode "$loc")))))
         loc)))
 
-(define-public locate-node (make-afunc-cache do-locate-node))
+(define-public locate-node (memoize-function-call do-locate-node))
 
 ;; filter only Cell membrane and compartments
 

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -37,7 +37,29 @@
 	          create-edge)
 )
 
-;;Define the parameters needed for GGI
+; ----------------------------------------------------
+
+(define-public (memoize-function-call FUNC)
+"
+  memoize-function-call - Thread-safe function caching.
+
+  This defines a cache for the function FUNC, assumed to be a function
+  taking a single Stom as input, and returning any output. The cache
+  records (memoizes) the return value returned by FUNC, and if it is
+  called a secnd time, or more, the cached value is returned. This can
+  save large amounts of time if FUNC is expensive.
+
+  This differs from ordinary caching/memoizing utilities as it provides
+  special handling for Atom arguments.
+"
+	(define mtx (make-mutex))
+	(define cache (make-afunc-cache FUNC))
+	(lambda (ATOM) (with-mutex mtx (cache ATOM)))
+)
+
+; ----------------------------------------------------
+
+;; Define the parameters needed for GGI
 (define-public biogrid-genes (make-parameter (make-atom-set)))
 (define-public biogrid-pairs (make-parameter (make-atom-set)))
 (define-public biogrid-reported-pathways (make-parameter (make-atom-set)))
@@ -190,26 +212,6 @@
 			(unlock-mutex run-query-mtx)
 			(run-query QUERY))
 	)
-)
-
-; ----------------------------------------------------
-
-(define-public (memoize-function-call FUNC)
-"
-  memoize-function-call - Thread-safe function caching.
-
-  This defines a cache for the function FUNC, assumed to be a function
-  taking a single Stom as input, and returning any output. The cache
-  records (memoizes) the return value returned by FUNC, and if it is
-  called a secnd time, or more, the cached value is returned. This can
-  save large amounts of time if FUNC is expensive.
-
-  This differs from ordinary caching/memoizing utilities as it provides
-  special handling for Atom arguments.
-"
-	(define mtx (make-mutex))
-	(define cache (make-afunc-cache FUNC))
-	(lambda (ATOM) (with-mutex mtx (cache ATOM)))
 )
 
 ; ----------------------------------------------------


### PR DESCRIPTION
There are two possible fixes for issue #144 - one is ton not use `par-map` in `main.scm`, The problem with `par-map` is that while it does reduce latency, it does so at considerable cost, I measure the following for multiple-threads:
```
Elapsed: 526.03 secs. Rate: 28.86 gc/min %cpu-GC: 113.2%  %cpu-use: 266.9%
```
vs single-theaded performance:
```
Elapsed: 814.31 secs. Rate: 19.82 gc/min %cpu-GC: 52.31%  %cpu-use: 139.1%
```
The single-threaded elapsed time is longer, bu the CPU usage is a lot lower.

Never the less, if you really want to use `par-map`, this patch fixes the crashes that would otherwise result.
It slows down overall performance by 2%.