### PR TITLE
Remove the unnecessary string conversions

### DIFF
--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -116,6 +116,6 @@ atomspace."
                  (biogrid-pairs (make-atom-set))
                  (biogrid-reported-pathways (make-atom-set)))
     (let* ([fns (parse-request genes-list file-name request)]
-           [result (par-map (lambda (x) (x)) fns)] )
+           [result (map (lambda (x) (x)) fns)] )
       (scm->json-string
-       (atomese-graph->scm (atomese-parser (format #f "~a" result)))))))
+       (atomese-graph->scm (atomese-parser result))))))

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -155,11 +155,11 @@ graph by mutating global variables."
       (unknown (pk 'unknown unknown #false))))
   (expr->graph expr))
 
-(define* (atomese-parser port #:optional mode)
+(define* (atomese-parser expr)
   (set! *nodes* '())
   (set! *edges* '())
   (set! *atoms* '())
   (set! *annotation* "")
   (set! *prev-annotation* "")
-  (atomese->graph port)
+  (atomese->graph expr)
   (make-graph *nodes* *edges*))

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -161,7 +161,5 @@ graph by mutating global variables."
   (set! *atoms* '())
   (set! *annotation* "")
   (set! *prev-annotation* "")
-  (atomese->graph
-   (with-input-from-string port
-     read))
+  (atomese->graph port)
   (make-graph *nodes* *edges*))

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -161,5 +161,5 @@ graph by mutating global variables."
   (set! *atoms* '())
   (set! *annotation* "")
   (set! *prev-annotation* "")
-  (atomese->graph expr)
+  (for-each atomese->graph expr)
   (make-graph *nodes* *edges*))


### PR DESCRIPTION
This PR removes the unnecessary string conversions that happens when passing the result of the annotation functions to the atomese parser. This partly fixes the guile heap blow as discussed in #111