### PR TITLE
Simplify find-go-term

### DIFF
--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -93,11 +93,12 @@ in the specified namespaces."
            (go-info parent-atom)))
       #f))
 
-(define-public (find-go-term g namespaces p)
+(define-public (find-go-term g namespaces num-parents)
 "
   The main function to find the go terms for a gene with a
   specification of the parents.
-  namespaces should be a list of strings.
+  `namespaces` should be a list of strings.
+  `num-parents` should be a number, the number of parents to look up.
 "
    (define (loop i ls acc)
       (cond 
@@ -113,7 +114,7 @@ in the specified namespaces."
    )
 
    (define res (find-memberln g namespaces))
-   (define parents (flatten (loop p res '())))
+   (define parents (flatten (loop num-parents res '())))
 
    (cons (node-info g) parents)
 )

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -103,7 +103,7 @@ in the specified namespaces."
 
    ;; Return a list of the parents of things in `lst`.
    (define (find-parents lst)
-      (append-map!
+      (append-map
          (lambda (item) (find-parent (gar item) namespaces))
          lst))
 

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -100,23 +100,27 @@ in the specified namespaces."
   `namespaces` should be a list of strings.
   `num-parents` should be a number, the number of parents to look up.
 "
-   (define (loop i ls acc)
-      (cond 
-        [(= i 0) (append ls acc)]
-        [(null? ls) acc]
-        [else (cons
-           (loop
-              (- i 1)
-              (find-parent (gar (car ls)) namespaces)
-              (append ls acc))
-           (loop i (cdr ls) '()))]
-      )
-   )
 
+   ;; Return a list of the parents of things in `lst`.
+   (define (find-parents lst)
+      (append-map!
+         (lambda (item) (find-parent (gar item) namespaces))
+         lst))
+
+   ;; depth-recursive loop. Look for parents of parents, etc.
+   ;; up to depth `i`.
+   (define (loop i lis acc)
+      (define next-acc (append lis acc))
+      (if (= i 0) next-acc
+         (loop (- i 1) (find-parents lis) next-acc)))
+
+   ; res is a list of .. what, exactly ???
    (define res (find-memberln g namespaces))
-   (define parents (flatten (loop num-parents res '())))
 
-   (cons (node-info g) parents)
+   ;; I don't think the flatten is needed any more, but whatever.
+   (define all-parents (flatten (loop num-parents res '())))
+
+   (cons (node-info g) all-parents)
 )
 
 (define-public (find-proteins-goterm gene namespace parent)

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -104,7 +104,9 @@ in the specified namespaces."
    ;; Return a list of the parents of things in `lst`.
    (define (find-parents lst)
       (append-map
-         (lambda (item) (find-parent (gar item) namespaces))
+         (lambda (item)
+            ; Something is sending us a stray #f for soe reason...
+            (if item (find-parent (gar item) namespaces) '()))
          lst))
 
    ;; depth-recursive loop. Look for parents of parents, etc.

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -93,13 +93,15 @@ in the specified namespaces."
            (go-info parent-atom)))
       #f))
 
-;;the main function to find the go terms for a gene with a specification of the parents
-(define-public find-go-term 
-  (lambda (g namespaces p)
-      (let (
-        [res (find-memberln g namespaces)]   
-      )
-      (define parents (flatten (let loop (
+(define-public (find-go-term g namespaces p)
+"
+  The main function to find the go terms for a gene with a
+  specification of the parents.
+  namespaces should be a list of strings.
+"
+   (define res (find-memberln g namespaces))
+
+   (define parents (flatten (let loop (
         [i p]
         [ls res]
         [acc '()]
@@ -111,9 +113,8 @@ in the specified namespaces."
           ]
       )
       )))
-       (cons (node-info g) parents)
-    )
-))
+   (cons (node-info g) parents)
+)
 
 (define-public (find-proteins-goterm gene namespace parent)
   "Find GO terms for proteins coded by the given gene."

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -117,11 +117,11 @@ in the specified namespaces."
       (if (= i 0) next-acc
          (loop (- i 1) (find-parents lis) next-acc)))
 
-   ; res is a list of .. what, exactly ???
+   ; res is list of the GO terms directly related to 
+   ; the input gene (g) that are members of the input namespaces
    (define res (find-memberln g namespaces))
 
-   ;; I don't think the flatten is needed any more, but whatever.
-   (define all-parents (flatten (loop num-parents res '())))
+   (define all-parents (loop num-parents res '()))
 
    (cons (node-info g) all-parents)
 )

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -109,8 +109,9 @@ in the specified namespaces."
             (if item (find-parent (gar item) namespaces) '()))
          lst))
 
-   ;; depth-recursive loop. Look for parents of parents, etc.
-   ;; up to depth `i`.
+   ;; breadth-first, depth-recursive loop. This gets all parents
+   ;; at depth `i` (thus, it's breadth-first) and then recurses
+   ;; to the next depth.
    (define (loop i lis acc)
       (define next-acc (append lis acc))
       (if (= i 0) next-acc

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -99,20 +99,22 @@ in the specified namespaces."
   specification of the parents.
   namespaces should be a list of strings.
 "
-   (define res (find-memberln g namespaces))
-
-   (define parents (flatten (let loop (
-        [i p]
-        [ls res]
-        [acc '()]
-      )
+   (define (loop i ls acc)
       (cond 
         [(= i 0) (append ls acc)]
         [(null? ls) acc]
-        [else (cons (loop (- i 1)  (find-parent (car (cog-outgoing-set (car ls))) namespaces) (append ls acc)) (loop i (cdr ls) '()))
-          ]
+        [else (cons
+           (loop
+              (- i 1)
+              (find-parent (gar (car ls)) namespaces)
+              (append ls acc))
+           (loop i (cdr ls) '()))]
       )
-      )))
+   )
+
+   (define res (find-memberln g namespaces))
+   (define parents (flatten (loop p res '())))
+
    (cons (node-info g) parents)
 )
 


### PR DESCRIPTION
I found the `find-go-term` function to be very hard to read and understand. This is a rewrite that cleanly splits it up into parts, and uses srfi-1 to manage the lists.  Its now a breadth-first search.