### PR TITLE
Write JSON output to file

### DIFF
--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -125,4 +125,4 @@
                                 )]
            )
 
-          (write-to-file (scm->json-string (atomese-graph->scm super-graph)) file-name file-name))))
+          (write-to-file (scm->json-string (atomese-graph->scm super-graph)) file-name file-name ".json"))))

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -125,4 +125,4 @@
                                 )]
            )
 
-          (scm->json-string (atomese-graph->scm super-graph)))))
+          (write-to-file (scm->json-string (atomese-graph->scm super-graph)) file-name file-name))))

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -34,7 +34,8 @@
 	#:use-module (ice-9 match)
 	#:use-module (ice-9 threads)
 	#:export (create-node
-	          create-edge)
+	          create-edge
+            write-to-file)
 )
 
 ; ----------------------------------------------------
@@ -291,7 +292,7 @@
  (string-append "https://www.ncbi.nlm.nih.gov/pubmed/?term=" (cadr (string-split nodename #\:)))
 )
 
-(define-public (write-to-file result id name)
+(define* (write-to-file result id name #:optional (ext ".scm"))
   (catch #t (lambda ()
     (let*
         (
@@ -304,7 +305,7 @@
               (string-append "/tmp/result/" id)
             )
             (string-append env-path "/" id))]
-          [file-name (string-append path "/" name ".scm")]
+          [file-name (string-append path "/" name ext)]
         )
         (if (not (file-exists? path))
             (mkdir path)

--- a/tests/main-tests.scm
+++ b/tests/main-tests.scm
@@ -30,7 +30,7 @@
 ;;This is because the function name `unknown-function` is not in the list `annotation-functions`
 (test-equal "validate-functions" 1 (length (parse-request (list "IGF1") "Dfaer" invalid-req)))
 
-(test-assert "annotate-genes" (string? (annotate-genes (list "IGF1") "Dfaer" req)))
+(test-equal "annotate-genes" #t ((lambda () (annotate-genes (list "IGF1") "Dfaer" req) (file-exists? "/tmp/result/Dfaer/Dfaer.json"))))
 
 (test-equal "find-genes" "1:" (substring (find-genes (list "IGF")) 0 2))
 


### PR DESCRIPTION
Instead of printing the parser output to `stdout`, write it to file. This is useful and saves tiny bit of code on the annotation service.