### PR TITLE
Improve the GO annotation with proteins

### DIFF
--- a/tests/main-tests.scm
+++ b/tests/main-tests.scm
@@ -36,7 +36,7 @@
 
 (define namespace (list "biological_process" "molecular_function" "cellular_component"))
 
-(test-equal "protein-goterm" 86 (length (cog-outgoing-set (find-proteins-goterm (GeneNode "IGF1") namespace 0))))
+(test-equal "protein-goterm" 14 (length (find-proteins-goterm (GeneNode "IGF1") namespace 0)))
 
 
 (test-equal "current_vs_prev_symbols" (ListLink) (find-protein-form (GeneNode "NOV")))


### PR DESCRIPTION
This PR fixes the following issues:
1. It handles the case where a gene doesn't have a coding protein in `find-proteins-goterm`
2. Adds `find-proteins` function that returns all proteins coded by a gene instead of returning one result like `find-protein-form`
3. Use `find-proteins` to annotate all the proteins of a gene with GO