### PR TITLE
Remove unnecessary string conversion when passing results to the parser

### DIFF
--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -119,7 +119,7 @@
                  (biogrid-reported-pathways (make-atom-set)))
     (let* ([fns (parse-request genes-list file-name request)]
            [result (par-map (lambda (x) (x)) fns)] 
-           [graphs (map (lambda (res) (atomese-parser (format #f "~a" res))) result)]
+           [graphs (map (lambda (res) (atomese-parser res)) result)]
            [super-graph (make-graph (append-map (lambda (graph) (graph-nodes graph)) graphs)
                                     (append-map (lambda (graph) (graph-edges graph)) graphs)
                                 )]

--- a/tests/parser-tests.scm
+++ b/tests/parser-tests.scm
@@ -59,10 +59,10 @@
          )
 ))
 
-(test-assert "atomese-parser"  (graph? (atomese-parser (format #f "~a" res))))
+(test-assert "atomese-parser"  (graph? (atomese-parser res)))
 
-(test-assert "node-count" (= (length (graph-nodes (atomese-parser (format #f "~a" res)))) 2))
+(test-assert "node-count" (= (length (graph-nodes (atomese-parser res))) 2))
 
-(test-assert "edge-count" (= (length (graph-edges (atomese-parser (format #f "~a" res)))) 1))
+(test-assert "edge-count" (= (length (graph-edges (atomese-parser res))) 1))
 
 (test-end "parser")


### PR DESCRIPTION
This PR removes the string conversion issue mentioned in #111 