### PR TITLE
Remove the current mult-threading

### DIFF
--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -118,7 +118,7 @@
                  (biogrid-pairs (make-atom-set))
                  (biogrid-reported-pathways (make-atom-set)))
     (let* ([fns (parse-request genes-list file-name request)]
-           [result (par-map (lambda (x) (x)) fns)] 
+           [result (map (lambda (x) (x)) fns)] 
            [graphs (map (lambda (res) (atomese-parser res)) result)]
            [super-graph (make-graph (append-map (lambda (graph) (graph-nodes graph)) graphs)
                                     (append-map (lambda (graph) (graph-edges graph)) graphs)

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -26,13 +26,11 @@
 	#:use-module (opencog bioscience)
 	#:use-module (annotation graph)
 	#:use-module (ice-9 optargs)
-;	#:use-module (rnrs base)
 	#:use-module (rnrs exceptions)
 	#:use-module (ice-9 textual-ports)
 	#:use-module (ice-9 regex)
 	#:use-module (srfi srfi-1)
 	#:use-module (ice-9 match)
-	#:use-module (ice-9 threads)
 	#:export (create-node
 	          create-edge
             write-to-file
@@ -54,9 +52,8 @@
   This differs from ordinary caching/memoizing utilities as it provides
   special handling for Atom arguments.
 "
-	(define mtx (make-mutex))
 	(define cache (make-afunc-cache FUNC))
-	(lambda (ATOM) (with-mutex mtx (cache ATOM)))
+	(lambda (ATOM) (cache ATOM))
 )
 
 ; ----------------------------------------------------


### PR DESCRIPTION
This fixes #198 and as @linas noted in #161 `par-map` introduces its own set of problems including #198 , which I suspect it has to do with the lack of locks in `make-atom-set` function (but I am only running two threads and one thread doesn't access the atom cache!). Hence getting rid of `par-map` and replacing it with other threading libraries (like on suggested in #197) maybe a good approach.