### PR TITLE
Add covid filter for biogrid

### DIFF
--- a/annotation/biogrid.scm
+++ b/annotation/biogrid.scm
@@ -37,26 +37,26 @@
                                          (parents 0)
                                          (coding #f)
                                          (noncoding #f)
-                                         (orgs #f)
+                                         (exclude-orgs #f)
                                          )
 	(define namespaces
 		(if (null? namespace) '() (string-split namespace #\ )))
 
   (let* (
-       [taxonomies (if orgs (string-split orgs #\ ) '())]
+       [exclude-taxonomies (if exclude-orgs (string-split exclude-orgs #\ ) '())]
        [result
           (append-map (lambda (gene)
             (match interaction
               ("Proteins"
                (append (match-gene-interactors (GeneNode gene)
-                            #t namespaces parents coding noncoding taxonomies)
+                            #t namespaces parents coding noncoding exclude-taxonomies)
                        (find-output-interactors (GeneNode gene)
-                            #t namespaces parents coding noncoding taxonomies)))
+                            #t namespaces parents coding noncoding exclude-taxonomies)))
               ("Genes"
                (append (match-gene-interactors (GeneNode gene)
-                            #f namespaces parents coding noncoding taxonomies)
+                            #f namespaces parents coding noncoding exclude-taxonomies)
                        (find-output-interactors (GeneNode gene)
-                            #f namespaces parents coding noncoding taxonomies))
+                            #f namespaces parents coding noncoding exclude-taxonomies))
                )))
           gene-nodes)]
          [res (ListLink (ConceptNode "biogrid-interaction-annotation")

--- a/annotation/biogrid.scm
+++ b/annotation/biogrid.scm
@@ -37,24 +37,27 @@
                                          (parents 0)
                                          (coding #f)
                                          (noncoding #f)
-                                         (covid #t)
+                                         (orgs #f)
                                          )
 	(define namespaces
 		(if (null? namespace) '() (string-split namespace #\ )))
 
-  (let* ([result
+  (let* (
+       [taxonomies (if orgs (string-split orgs #\ ) '())]
+       [result
           (append-map (lambda (gene)
             (match interaction
               ("Proteins"
                (append (match-gene-interactors (GeneNode gene)
-                            #t namespaces parents coding noncoding covid)
+                            #t namespaces parents coding noncoding taxonomies)
                        (find-output-interactors (GeneNode gene)
-                            #t namespaces parents coding noncoding covid)))
+                            #t namespaces parents coding noncoding taxonomies)))
               ("Genes"
                (append (match-gene-interactors (GeneNode gene)
-                            #f namespaces parents coding noncoding covid)
+                            #f namespaces parents coding noncoding taxonomies)
                        (find-output-interactors (GeneNode gene)
-                            #f namespaces parents coding noncoding covid)))))
+                            #f namespaces parents coding noncoding taxonomies))
+               )))
           gene-nodes)]
          [res (ListLink (ConceptNode "biogrid-interaction-annotation")
                         (ListLink result))])

--- a/annotation/biogrid.scm
+++ b/annotation/biogrid.scm
@@ -36,7 +36,9 @@
                                          (namespace "")
                                          (parents 0)
                                          (coding #f)
-                                         (noncoding #f))
+                                         (noncoding #f)
+                                         (covid #t)
+                                         )
 	(define namespaces
 		(if (null? namespace) '() (string-split namespace #\ )))
 
@@ -45,14 +47,14 @@
             (match interaction
               ("Proteins"
                (append (match-gene-interactors (GeneNode gene)
-                            #t namespaces parents coding noncoding)
+                            #t namespaces parents coding noncoding covid)
                        (find-output-interactors (GeneNode gene)
-                            #t namespaces parents coding noncoding)))
+                            #t namespaces parents coding noncoding covid)))
               ("Genes"
                (append (match-gene-interactors (GeneNode gene)
-                            #f namespaces parents coding noncoding)
+                            #f namespaces parents coding noncoding covid)
                        (find-output-interactors (GeneNode gene)
-                            #f namespaces parents coding noncoding)))))
+                            #f namespaces parents coding noncoding covid)))))
           gene-nodes)]
          [res (ListLink (ConceptNode "biogrid-interaction-annotation")
                         (ListLink result))])

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -464,21 +464,20 @@
             (generate-result gene act-gene do-protein namespace parents coding non-coding))
 
          (run-query (Get
-            (VariableList
-               (TypedVariable (Variable "$a") (Type 'GeneNode)))
-                  (Evaluation 
+                  (And 
+                     (Evaluation 
                      (Predicate "interacts_with")
                      (SetLink gene (Variable "$a")))
-                  (map (lambda (org)
-                     (Absent 
-                        (Evaluation (Predicate "from_organism")
-                           (List 
-                              (Variable "$a")
-                              (ConceptNode (string-append "TaxonomyID:" org))
+                     (map (lambda (org)
+                        (Absent 
+                           (Evaluation (Predicate "from_organism")
+                              (List 
+                                 (Variable "$a")
+                                 (ConceptNode (string-append "TaxonomyID:" org))
+                              )
                            )
                         )
-                     )
-                  ) orgs)
+                     ) orgs))
                ))
             )
 )
@@ -500,27 +499,28 @@
             (VariableList
                (TypedVariable (Variable "$a") (Type 'GeneNode))
                (TypedVariable (Variable "$b") (Type 'GeneNode)))
-
-            (And
-               (Evaluation (Predicate "interacts_with")
+               (And 
+                  (Evaluation (Predicate "interacts_with")
                   (SetLink gene (Variable "$a")))
 
-               (Evaluation (Predicate "interacts_with")
-                  (SetLink (Variable "$a") (Variable "$b")))
+                  (Evaluation (Predicate "interacts_with")
+                     (SetLink (Variable "$a") (Variable "$b")))
 
-               (Evaluation (Predicate "interacts_with")
-                  (SetLink gene (Variable "$b")))
-               (map (lambda (org)
-                     (Absent 
-                        (Evaluation (Predicate "from_organism")
-                           (List 
-                              (Variable "$a")
-                              (ConceptNode (string-append "TaxonomyID:" org))
+                  (Evaluation (Predicate "interacts_with")
+                     (SetLink gene (Variable "$b")))
+                  (map (lambda (org)
+                        (Absent 
+                           (Evaluation (Predicate "from_organism")
+                              (List 
+                                 (Variable "$a")
+                                 (ConceptNode (string-append "TaxonomyID:" org))
+                              )
                            )
                         )
-                     )
-                  ) orgs))
-            )))  
+                     ) orgs)
+               
+               )
+         )))  
 )
 
 ;; ------------------------------------------------------

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -453,7 +453,7 @@
 ; ------------------------------------
 
 
-(define-public (match-gene-interactors gene do-protein namespace parents coding non-coding orgs)
+(define-public (match-gene-interactors gene do-protein namespace parents coding non-coding exclude-orgs)
 "
   match-gene-interactors - Finds genes interacting with a given gene
 
@@ -477,12 +477,12 @@
                               )
                            )
                         )
-                     ) orgs))
+                     ) exclude-orgs))
                ))
             )
 )
 
-(define-public (find-output-interactors gene do-protein namespace parents coding non-coding orgs)
+(define-public (find-output-interactors gene do-protein namespace parents coding non-coding exclude-orgs)
 "
   find-output-interactors -- Finds output genes interacting with each-other
 
@@ -517,7 +517,7 @@
                               )
                            )
                         )
-                     ) orgs)
+                     ) exclude-orgs)
                
                )
          )))  

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -453,24 +453,51 @@
 ; ------------------------------------
 
 
-(define-public (match-gene-interactors gene do-protein namespace parents coding non-coding)
+(define-public (match-gene-interactors gene do-protein namespace parents coding non-coding covid)
 "
   match-gene-interactors - Finds genes interacting with a given gene
 
   If do-protein is #t then protein interactions are included.
 "
-	(map
-		(lambda (act-gene)
-			(generate-result gene act-gene do-protein namespace parents coding non-coding))
+   (if covid 
+      (map
+         (lambda (act-gene)
+            (generate-result gene act-gene do-protein namespace parents coding non-coding))
 
-		(run-query (Get
-			(VariableList
-				(TypedVariable (Variable "$a") (Type 'GeneNode)))
-						(Evaluation (Predicate "interacts_with")
-							(SetLink gene (Variable "$a"))))))
+         (run-query (Get
+            (VariableList
+               (TypedVariable (Variable "$a") (Type 'GeneNode)))
+                  (Evaluation 
+                     (Predicate "interacts_with")
+                     (SetLink gene (Variable "$a")))
+               )))
+
+      (map
+         (lambda (act-gene)
+            (generate-result gene act-gene do-protein namespace parents coding non-coding))
+
+         (run-query (Get
+            (VariableList
+               (TypedVariable (Variable "$a") (Type 'GeneNode)))
+                     (And
+                        (Not 
+                           (Evaluation (Predicate "from_organism")
+                              (List 
+                                 gene
+                                 (ConceptNode "TaxonomyID:2697049")
+                              )
+                        ))
+
+                        (Evaluation 
+                           (Predicate "interacts_with")
+                           (SetLink gene (Variable "$a")))
+                     ))))
+   
+   )
+	
 )
 
-(define-public (find-output-interactors gene do-protein namespace parents coding non-coding)
+(define-public (find-output-interactors gene do-protein namespace parents coding non-coding covid)
 "
   find-output-interactors -- Finds output genes interacting with each-other
 
@@ -479,25 +506,55 @@
 
   If do-protein is #t then protein interactions are included.
 "
-	(map
-		(lambda (gene-pair)
-			(generate-result (gar gene-pair) (gdr gene-pair) do-protein namespace parents coding non-coding))
+   (if covid
+      (map
+         (lambda (gene-pair)
+            (generate-result (gar gene-pair) (gdr gene-pair) do-protein namespace parents coding non-coding))
 
-		(run-query (Get
-			(VariableList
-				(TypedVariable (Variable "$a") (Type 'GeneNode))
-				(TypedVariable (Variable "$b") (Type 'GeneNode)))
+         (run-query (Get
+            (VariableList
+               (TypedVariable (Variable "$a") (Type 'GeneNode))
+               (TypedVariable (Variable "$b") (Type 'GeneNode)))
 
-			(And
-				(Evaluation (Predicate "interacts_with")
-					(SetLink gene (Variable "$a")))
+            (And
+               (Evaluation (Predicate "interacts_with")
+                  (SetLink gene (Variable "$a")))
 
-				(Evaluation (Predicate "interacts_with")
-					(SetLink (Variable "$a") (Variable "$b")))
+               (Evaluation (Predicate "interacts_with")
+                  (SetLink (Variable "$a") (Variable "$b")))
 
-				(Evaluation (Predicate "interacts_with")
-					(SetLink gene (Variable "$b")))
-			))))
+               (Evaluation (Predicate "interacts_with")
+                  (SetLink gene (Variable "$b")))
+            ))))  
+
+         (map
+            (lambda (gene-pair)
+               (generate-result (gar gene-pair) (gdr gene-pair) do-protein namespace parents coding non-coding))
+
+            (run-query (Get
+               (VariableList
+                  (TypedVariable (Variable "$a") (Type 'GeneNode))
+                  (TypedVariable (Variable "$b") (Type 'GeneNode)))
+
+               (And
+                  (Not 
+                           (Evaluation (Predicate "from_organism")
+                              (List 
+                                 gene
+                                 (ConceptNode "TaxonomyID:2697049")
+                              )
+                        ))
+                  (Evaluation (Predicate "interacts_with")
+                     (SetLink gene (Variable "$a")))
+
+                  (Evaluation (Predicate "interacts_with")
+                     (SetLink (Variable "$a") (Variable "$b")))
+
+                  (Evaluation (Predicate "interacts_with")
+                     (SetLink gene (Variable "$b")))
+               )))) 
+   
+   )
 )
 
 ;; ------------------------------------------------------

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -453,13 +453,12 @@
 ; ------------------------------------
 
 
-(define-public (match-gene-interactors gene do-protein namespace parents coding non-coding covid)
+(define-public (match-gene-interactors gene do-protein namespace parents coding non-coding orgs)
 "
   match-gene-interactors - Finds genes interacting with a given gene
 
   If do-protein is #t then protein interactions are included.
 "
-   (if covid 
       (map
          (lambda (act-gene)
             (generate-result gene act-gene do-protein namespace parents coding non-coding))
@@ -470,34 +469,21 @@
                   (Evaluation 
                      (Predicate "interacts_with")
                      (SetLink gene (Variable "$a")))
-               )))
-
-      (map
-         (lambda (act-gene)
-            (generate-result gene act-gene do-protein namespace parents coding non-coding))
-
-         (run-query (Get
-            (VariableList
-               (TypedVariable (Variable "$a") (Type 'GeneNode)))
-                     (And
-                        (Not 
-                           (Evaluation (Predicate "from_organism")
-                              (List 
-                                 gene
-                                 (ConceptNode "TaxonomyID:2697049")
-                              )
-                        ))
-
-                        (Evaluation 
-                           (Predicate "interacts_with")
-                           (SetLink gene (Variable "$a")))
-                     ))))
-   
-   )
-	
+                  (map (lambda (org)
+                     (Absent 
+                        (Evaluation (Predicate "from_organism")
+                           (List 
+                              (Variable "$a")
+                              (ConceptNode (string-append "TaxonomyID:" org))
+                           )
+                        )
+                     )
+                  ) orgs)
+               ))
+            )
 )
 
-(define-public (find-output-interactors gene do-protein namespace parents coding non-coding covid)
+(define-public (find-output-interactors gene do-protein namespace parents coding non-coding orgs)
 "
   find-output-interactors -- Finds output genes interacting with each-other
 
@@ -506,7 +492,6 @@
 
   If do-protein is #t then protein interactions are included.
 "
-   (if covid
       (map
          (lambda (gene-pair)
             (generate-result (gar gene-pair) (gdr gene-pair) do-protein namespace parents coding non-coding))
@@ -525,36 +510,17 @@
 
                (Evaluation (Predicate "interacts_with")
                   (SetLink gene (Variable "$b")))
-            ))))  
-
-         (map
-            (lambda (gene-pair)
-               (generate-result (gar gene-pair) (gdr gene-pair) do-protein namespace parents coding non-coding))
-
-            (run-query (Get
-               (VariableList
-                  (TypedVariable (Variable "$a") (Type 'GeneNode))
-                  (TypedVariable (Variable "$b") (Type 'GeneNode)))
-
-               (And
-                  (Not 
-                           (Evaluation (Predicate "from_organism")
-                              (List 
-                                 gene
-                                 (ConceptNode "TaxonomyID:2697049")
-                              )
-                        ))
-                  (Evaluation (Predicate "interacts_with")
-                     (SetLink gene (Variable "$a")))
-
-                  (Evaluation (Predicate "interacts_with")
-                     (SetLink (Variable "$a") (Variable "$b")))
-
-                  (Evaluation (Predicate "interacts_with")
-                     (SetLink gene (Variable "$b")))
-               )))) 
-   
-   )
+               (map (lambda (org)
+                     (Absent 
+                        (Evaluation (Predicate "from_organism")
+                           (List 
+                              (Variable "$a")
+                              (ConceptNode (string-append "TaxonomyID:" org))
+                           )
+                        )
+                     )
+                  ) orgs))
+            )))  
 )
 
 ;; ------------------------------------------------------

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -86,9 +86,9 @@
 				(if (null? lst) (ConceptNode "N/A") (car lst))))
 
 	(if (cog-node? node)
-    (list
+    (append
       (find-organism node)
-		  (EvaluationLink (PredicateNode "has_name") (ListLink node (node-name node)))
+		  (list (EvaluationLink (PredicateNode "has_name") (ListLink node (node-name node))))
     )
 		(ListLink))
 )


### PR DESCRIPTION
This PR adds a filter that specifies whether to include COVID-19 genes in the biogrid annotation. @linas can you please check if my usage of `NotLink` in this context is correct?