### PR TITLE
Improve the module reflection and remove the usage of current-module

### DIFF
--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -462,3 +462,17 @@
       #f
   )
 )
+
+(define-public (find-module name modules)
+  "
+  Return the reference to an object in the list of modules with the specified name
+  "
+    (let (
+        [var  (any (lambda (mod) (module-variable (resolve-module mod) (string->symbol name))) modules)]
+    )
+        (if var 
+            (variable-ref var)
+            #f
+        )
+    )
+)


### PR DESCRIPTION
This removes the usage of `current-module` to search for annotation functions which can be unsafe. It implements a module reflection function and only searches for a symbol in a list of pre-specified modules. Look this [comment](https://github.com/MOZI-AI/annotation-scheme/pull/123#issuecomment-584252520) by @rekado 