### PR TITLE
Refactor the code to make it easy for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,4 +223,4 @@ build-aux/missing
 
 Makefile
 
-build/
+build/**

--- a/annotation/biogrid.scm
+++ b/annotation/biogrid.scm
@@ -26,8 +26,8 @@
 	#:use-module (opencog exec)
 	#:use-module (opencog bioscience)
 	#:use-module (annotation parser)
-    #:use-module (ice-9 match)
-    #:use-module (srfi srfi-1)
+      #:use-module (ice-9 match)
+      #:use-module (srfi srfi-1)
 	#:export (biogrid-interaction-annotation))
 
 (define* (biogrid-interaction-annotation gene-nodes
@@ -51,22 +51,18 @@
      (for-each (lambda (gene)
             (match interaction
               ("Proteins"
-               (begin (match-gene-interactors (GeneNode gene) 
-                            chans #t 
-                            namespaces parents regulates part-of bi-dir
-                            coding noncoding exclude-taxonomies)
-                       (find-output-interactors (GeneNode gene)
-                             chans #t 
-                             namespaces parents regulates part-of bi-dir
-                             coding noncoding exclude-taxonomies)))
+               (begin (send-message (match-gene-interactors (GeneNode gene) 
+                         #t namespaces parents regulates part-of bi-dir
+                            coding noncoding exclude-taxonomies) chans)
+                       (send-message (find-output-interactors (GeneNode gene)
+                             #t namespaces parents regulates part-of bi-dir
+                             coding noncoding exclude-taxonomies) chans)))
               ("Genes"
-               (begin (match-gene-interactors (GeneNode gene)
-                              chans #f 
+               (begin (send-message (match-gene-interactors (GeneNode gene) #f 
                               namespaces parents regulates part-of bi-dir
-                              coding noncoding exclude-taxonomies)
-                       (find-output-interactors (GeneNode gene)
-                             chans #f 
-                             namespaces parents regulates part-of bi-dir
-                             coding noncoding exclude-taxonomies)))))
+                              coding noncoding exclude-taxonomies) chans)
+                       (send-message (find-output-interactors (GeneNode gene)
+                             #f namespaces parents regulates part-of bi-dir
+                             coding noncoding exclude-taxonomies) chans)))))
           gene-nodes)
 )

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -679,15 +679,15 @@
 ; ------------------------------------
 
 
-(define-public (match-gene-interactors gene chans do-protein namespace parents regulates part-of bi-dir coding non-coding exclude-orgs)
+(define-public (match-gene-interactors gene do-protein namespace parents regulates part-of bi-dir coding non-coding exclude-orgs)
 "
   match-gene-interactors - Finds genes interacting with a given gene
 
   If do-protein is #t then protein interactions are included.
 "
-	(for-each
+	(append-map
 		(lambda (act-gene)
-			(generate-result gene act-gene chans do-protein namespace parents regulates part-of bi-dir coding non-coding))
+			(generate-result gene act-gene do-protein namespace parents regulates part-of bi-dir coding non-coding))
 
 		(run-query (Get
                   (And 
@@ -700,15 +700,10 @@
                               (List 
                                  (Variable "$a")
                                  (ConceptNode (string-append "ncbi:" org))
-                              )
-                           )
-                        )
-                     ) exclude-orgs))
-               ))
-      )
-)
+                              )))) exclude-orgs))
+               ))))
 
-(define-public (find-output-interactors gene chans do-protein namespace parents regulates part-of bi-dir coding non-coding exclude-orgs)
+(define-public (find-output-interactors gene do-protein namespace parents regulates part-of bi-dir coding non-coding exclude-orgs)
 "
   find-output-interactors -- Finds output genes interacting with each-other
 
@@ -717,9 +712,9 @@
 
   If do-protein is #t then protein interactions are included.
 "
-	(for-each
+	(append-map
 		(lambda (gene-pair)
-			(generate-result (gar gene-pair) (gdr gene-pair) chans do-protein namespace parents regulates part-of bi-dir coding non-coding))
+			(generate-result (gar gene-pair) (gdr gene-pair) do-protein namespace parents regulates part-of bi-dir coding non-coding))
 
 		(run-query (Get
             (VariableList
@@ -740,25 +735,14 @@
                               (Evaluation (Predicate "from_organism")
                                  (List 
                                     (Variable "$a")
-                                    (ConceptNode (string-append "ncbi:" org))
-                                 )
-                              )
-                           )
+                                    (ConceptNode (string-append "ncbi:" org)))))
                            (Absent 
                               (Evaluation (Predicate "from_organism")
                                  (List 
                                     (Variable "$b")
                                     (ConceptNode (string-append "ncbi:" org))
-                                 )
-                              )
-                           )
-                        )
-                        
-                     ) exclude-orgs)
-               
-               )
-         )))
-)
+                                 ))))
+                        ) exclude-orgs))))))
 
 ;; ------------------------------------------------------
 
@@ -871,7 +855,7 @@
 )
 
 
-(define-public (generate-result gene-a gene-b chans do-protein namespaces num-parents  regulates part-of bi-dir coding-rna non-coding-rna)
+(define-public (generate-result gene-a gene-b do-protein namespaces num-parents  regulates part-of bi-dir coding-rna non-coding-rna)
 "
   generate-result -- add info about matched variable nodes
 
@@ -890,9 +874,9 @@
 		    (equal? (cog-type gene-b) 'VariableNode))
 		(ListLink)
 		(let* (
-				[already-done-a ((biogrid-genes) gene-a)]
-				[already-done-b ((biogrid-genes) gene-b)]
-            [already-done-pair ((biogrid-pairs) (List gene-a gene-b))]
+				[already-done-a ((intr-genes) gene-a)]
+				[already-done-b ((intr-genes) gene-b)]
+            [already-done-pair ((gene-pairs) (List gene-a gene-b))]
 
 				[output (find-pubmed-id gene-a gene-b)]
             [interaction (if do-protein
@@ -925,15 +909,13 @@
                           (find-rna gene-b coding-rna non-coding-rna do-protein)
                           (Concept "biogrid-interaction-annotation"))
                         '()     
-                     )
-                          
-                     ])
+                     )])
                       (if do-protein
                         (let ([coding-prot-a (find-protein-form gene-a)]
                               [coding-prot-b (find-protein-form gene-b)])
                         (if (not (or (equal? coding-prot-a (ListLink))
                                 (equal? coding-prot-b (ListLink))))
-                          (send-message (list
+                          (append (list
                             interaction
                             (Evaluation (Predicate "expresses") (List gene-a coding-prot-a))
                             (node-info gene-a)
@@ -942,68 +924,60 @@
                             (Evaluation (Predicate "expresses") (List gene-b coding-prot-b))
                             (node-info gene-b)
                             (node-info coding-prot-b)
-                            (locate-node coding-prot-b)
+                            (locate-node coding-prot-b))
                             go-cross-annotation
-                            rna-cross-annotation
-                          ) chans)
-                        ))
-                      (send-message (list
-                          interaction
-                          (node-info gene-a)
-                          (locate-node gene-a)
-                          (node-info gene-b)
-                          (locate-node gene-b)
-                          go-cross-annotation
-                          rna-cross-annotation
-                      ) chans)
-                    )
-                  ))
+                            rna-cross-annotation) ))
+
+                           (append (list
+                              interaction
+                              (node-info gene-a)
+                              (locate-node gene-a)
+                              (node-info gene-b)
+                              (locate-node gene-b))
+                              go-cross-annotation
+                              rna-cross-annotation))))
 
               ;; One of the two genes is done already. Do the other one.
               ((or (not already-done-a) (not already-done-b))
-              (let* (
-                  [gene-x (if already-done-a gene-b gene-a)]
-                  [go-cross-annotation
-                     (if (null? namespaces) '()
-                        (list
-                           (Concept "gene-go-annotation")
-                           (find-go-term gene-x namespaces num-parents regulates part-of bi-dir)
-                           (Concept "biogrid-interaction-annotation"))
-                     )]
-                  [rna-cross-annotation
-                     (if (or coding-rna non-coding-rna)
-                        (list
-                           (Concept "rna-annotation")
-                           (find-rna gene-x coding-rna non-coding-rna do-protein)
-                           (Concept "biogrid-interaction-annotation"))
-                        '()
-                    )])
-                 (if do-protein
-                    (let ([coding-prot (find-protein-form gene-x)])
-                       (if (not (equal? coding-prot (ListLink)))
-                          (send-message (list
-                            interaction
-                            (Evaluation (Predicate "expresses") (List gene-x coding-prot))
-                            (node-info gene-x)
-                            (node-info coding-prot)
-                            (locate-node coding-prot)
-                            go-cross-annotation
-                            rna-cross-annotation) chans)
-                    ))
-                    (send-message (list
-                       interaction
-                       (node-info gene-x)
-                       (locate-node  gene-x)
-                       go-cross-annotation
-                       rna-cross-annotation) chans)
-                )))
+               (let* (
+                     [gene-x (if already-done-a gene-b gene-a)]
+                     [go-cross-annotation
+                        (if (null? namespaces) '()
+                           (list
+                              (Concept "gene-go-annotation")
+                              (find-go-term gene-x namespaces num-parents regulates part-of bi-dir)
+                              (Concept "biogrid-interaction-annotation"))
+                        )]
+                     [rna-cross-annotation
+                        (if (or coding-rna non-coding-rna)
+                           (list
+                              (Concept "rna-annotation")
+                              (find-rna gene-x coding-rna non-coding-rna do-protein)
+                              (Concept "biogrid-interaction-annotation"))
+                           '()
+                     )])
+                  (if do-protein
+                     (let ([coding-prot (find-protein-form gene-x)])
+                        (if (not (equal? coding-prot (ListLink)))
+                           (append (list
+                              interaction
+                              (Evaluation (Predicate "expresses") (List gene-x coding-prot))
+                              (node-info gene-x)
+                              (node-info coding-prot)
+                              (locate-node coding-prot))
+                              go-cross-annotation
+                              rna-cross-annotation)
+                     ))
+                     (append (list
+                        interaction
+                        (node-info gene-x)
+                        (locate-node  gene-x)
+                        go-cross-annotation)
+                        rna-cross-annotation)
+                  )))
 
               ;;; Both of the genes have been done.
-              (else (if (not already-done-pair)  (send-message interaction chans)))
-          )
-      )
-   )
-)
+              (else (if (not already-done-pair)  (list interaction)))))))
 
 ;; ------------------------------------------------------
 

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -872,7 +872,7 @@
 	(if
 		(or (equal? (cog-type gene-a) 'VariableNode)
 		    (equal? (cog-type gene-b) 'VariableNode))
-		(ListLink)
+		   '()
 		(let* (
 				[already-done-a ((intr-genes) gene-a)]
 				[already-done-b ((intr-genes) gene-b)]
@@ -926,7 +926,9 @@
                             (node-info coding-prot-b)
                             (locate-node coding-prot-b))
                             go-cross-annotation
-                            rna-cross-annotation) ))
+                            rna-cross-annotation)
+
+                            '()))
 
                            (append (list
                               interaction
@@ -967,6 +969,7 @@
                               (locate-node coding-prot))
                               go-cross-annotation
                               rna-cross-annotation)
+                           '()
                      ))
                      (append (list
                         interaction
@@ -977,7 +980,7 @@
                   )))
 
               ;;; Both of the genes have been done.
-              (else (if (not already-done-pair)  (list interaction)))))))
+              (else (if (not already-done-pair)  (list interaction) '()))))))
 
 ;; ------------------------------------------------------
 

--- a/annotation/functions.scm
+++ b/annotation/functions.scm
@@ -256,17 +256,12 @@
    (define (find-go-plus-info ln)
       (if (equal? go-term (gadr ln))
            (go-info (gddr ln))
-           (go-info (gadr ln))
-       )
-   )
+           (go-info (gadr ln))))
    (let (
       [go-reg-terms (if regulates (find-go-regulates (Set go-term (scm->stv bi-direction))) '())]
-      [go-part-terms (if part_of (find-part-of (Set go-term (scm->stv bi-direction))) '())]
-   ) 
+      [go-part-terms (if part_of (find-part-of (Set go-term (scm->stv bi-direction))) '())]) 
       (append go-reg-terms go-part-terms (append-map find-go-plus-info go-reg-terms) 
-         (append-map find-go-plus-info go-part-terms))
-   )
-)
+         (append-map find-go-plus-info go-part-terms))))
 
 (define-public (find-proteins-goterm gene namespace parent regulates part-of bi-dir)
   "Find GO terms for proteins coded by the given gene."
@@ -1163,67 +1158,4 @@
       (Evaluation
         (Predicate "GO_namespace")
         (List go-term var-ns))))
-)
-
-(define-public (find-go-has-part go-term)
-"
-  find-go-has-part GO-TERM
-
-  Find the other GO term that is linked with GO-TERM with GO_has_part predicate.
-"
-  (define var-go-term (Variable "$go-term"))
-
-  (run-query
-    (Bind
-      (TypedVariable var-go-term (Type "ConceptNode"))
-      (Present
-        (Evaluation
-          (Predicate "GO_has_part")
-          (List go-term var-go-term)))
-      (Evaluation
-        (Predicate "GO_has_part")
-        (List go-term var-go-term))))
-)
-
-(define-public (find-go-regulates go-term)
-"
-  find-go-regulates GO-TERM
-
-  Find the other GO terms that are being regulated by GO-TERM,
-  this includes both positive and negative regulation.
-"
-  (define var-go-term (Variable "$go-term"))
-
-  (append
-    (run-query
-      (Bind
-        (TypedVariable var-go-term (Type "ConceptNode"))
-        (Present
-          (Evaluation
-            (Predicate "GO_regulates")
-            (List go-term var-go-term)))
-        (Evaluation
-          (Predicate "GO_regulates")
-          (List go-term var-go-term))))
-    (run-query
-      (Bind
-        (TypedVariable var-go-term (Type "ConceptNode"))
-        (Present
-          (Evaluation
-            (Predicate "GO_positively_regulates")
-            (List go-term var-go-term)))
-        (Evaluation
-          (Predicate "GO_positively_regulates")
-          (List go-term var-go-term))))
-    (run-query
-      (Bind
-        (TypedVariable var-go-term (Type "ConceptNode"))
-        (Present
-          (Evaluation
-            (Predicate "GO_negatively_regulates")
-            (List go-term var-go-term)))
-        (Evaluation
-          (Predicate "GO_negatively_regulates")
-          (List go-term var-go-term))))
-  )
 )

--- a/annotation/gene-go.scm
+++ b/annotation/gene-go.scm
@@ -40,10 +40,8 @@
                 (send-message (find-go-term (GeneNode gene) (string-split namespace #\space) parents regulates part-of bi-dir) chans)
 
                 (send-message (find-proteins-goterm (GeneNode gene) (string-split namespace #\space) parents regulates part-of bi-dir) chans)                
-(send-message (find-drugs-protein (GeneNode gene) (string-split namespace #\space)) chans)
-              )
-              
+                (send-message (find-drugs-protein (GeneNode gene) (string-split namespace #\space)) chans)
+              )      
               (send-message (find-go-term (GeneNode gene) (string-split namespace #\space) parents regulates part-of bi-dir) chans)
             )
-          ) gene-nodes)
-)
+          ) gene-nodes))

--- a/annotation/gene-pathway.scm
+++ b/annotation/gene-pathway.scm
@@ -65,9 +65,7 @@
                               )) pathways))
                         gene-nodes)
           )
-        )              
-    
-  ))
+)))
 
 (define (smpdb gene chans prot? sm? namespaces num-parents regulates part-of bi-dir biogrid string coding-rna non-coding-rna)
 "

--- a/annotation/gene-record.scm
+++ b/annotation/gene-record.scm
@@ -21,25 +21,19 @@
     #:use-module (rnrs records inspection)
     #:use-module (rnrs records syntactic)
     #:use-module (ice-9 match)
+    #:use-module (srfi srfi-43)
     #:export (make-gene
               make-gene-info 
-              gene-record->scm
-    )
-)
+              gene-record->scm))
 
 (define-record-type gene
     (fields name 
             current
-            similar
-    )
-)
+            similar))
 
 (define-record-type gene-info
     (fields (mutable current)
-            (mutable similar) 
-
-    )
-)
+            (mutable similar)))
 
 (define (gene-record->scm record)
     (define record->scm
@@ -47,11 +41,7 @@
             ((? gene? rec)
                 `(("symbol" . ,(gene-name rec))
                   ("current" . ,(gene-current rec))
-                  ("similar" . ,(gene-similar rec))
-                )
-            )
-            (anything anything)
-        )
-    )
-    (record->scm record)
-)
+                  ("similar" . ,(list->vector (gene-similar rec)))
+                ))
+            (anything anything)))
+    (record->scm record))

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -58,16 +58,10 @@
                         (let* ([curr (find-current-symbol g)])
                           (if (null? curr)
                             #f
-                            (make-gene g (car curr) '())
-                          )
-                        )
-                    )
-                ) gene-list)))
+                            (make-gene g (car curr) '()))))) gene-list)))
         (if (null? records)
           "[]"
-          (scm->json-string (list->vector (map gene-record->scm records)))
-        )  
-      ))
+          (scm->json-string (list->vector (map gene-record->scm records))))))
 
 (define-public (gene-info genes chans)
   "Add the name and description of gene nodes to the given list of GENES."
@@ -85,12 +79,11 @@
 
 (define-public (parse-request req)
     (let (
-        (table (if (string? req) (json-string->scm req) (json-string->scm (utf8->string (u8-list->bytevector req))) ))
-    )
+        (table (if (string? req) (json-string->scm req) (json-string->scm (utf8->string (u8-list->bytevector req))))))
+
       (vector->list (vector-map (lambda (i elm)
         (let  (
-            (func (find-module (assoc-ref elm "functionName") mods))
-          )
+            (func (find-module (assoc-ref elm "functionName") mods)))
             (if func 
                 (let* (                
                   (filters (assoc-ref elm "filters"))
@@ -103,13 +96,9 @@
                               (string->number val)
                               (if (or (string=? val "True") (string=? val "False"))
                                 (str->tv val)
-                                val
-                              ))))) filters))))
-                  )
+                                val ))))) filters)))))
                   (cons func args))
-                '()
-            ))) table))
-))
+                '()))) table))))
 
 (define (process-request item-list file-name request)
   (run-fibers

--- a/annotation/main.scm
+++ b/annotation/main.scm
@@ -144,8 +144,8 @@
 )
 
 (define-public (annotate-genes genes-list file-name request)
-  (parameterize ((biogrid-genes (make-atom-set))
-                 (biogrid-pairs (make-atom-set))
+  (parameterize ((intr-genes (make-atom-set))
+                 (gene-pairs (make-atom-set))
                  (biogrid-reported-pathways (make-atom-set))
                 )
     (process-request genes-list file-name request)

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -176,7 +176,7 @@ graph by mutating global variables."
       (unknown (pk 'unknown unknown #false))))
   (expr->graph expr))
 
-(define* (atomese-parser in-chan port)
+(define* (atomese-parser proc)
   (set! *nodes* '())
   (set! *edges* '())
   (set! *atoms* '())
@@ -185,18 +185,11 @@ graph by mutating global variables."
   
 
   (let loop (
-      (msg (get-message in-chan))
+      (msg (proc))
    )
     (if (equal? msg 'eof)
-       (begin 
-          (scm->json (atomese-graph->scm (make-graph *nodes* *edges*)) port)
-          (close-port port)
-       )
+        (atomese-graph->scm (make-graph *nodes* *edges*))
       (begin 
          (atomese->graph msg)
-         (loop (get-message in-chan))
-      )
-    )
-  )
-)
+         (loop (proc))))))
 

--- a/annotation/parser.scm
+++ b/annotation/parser.scm
@@ -176,7 +176,7 @@ graph by mutating global variables."
       (unknown (pk 'unknown unknown #false))))
   (expr->graph expr))
 
-(define* (atomese-parser proc)
+(define* (atomese-parser proc parser-port)
   (set! *nodes* '())
   (set! *edges* '())
   (set! *atoms* '())
@@ -188,7 +188,11 @@ graph by mutating global variables."
       (msg (proc))
    )
     (if (equal? msg 'eof)
-        (atomese-graph->scm (make-graph *nodes* *edges*))
+      (let ((scm-graph (atomese-graph->scm (make-graph *nodes* *edges*))))
+          (scm->json scm-graph parser-port)
+          (force-output parser-port)
+          (close-port parser-port)
+      )
       (begin 
          (atomese->graph msg)
          (loop (proc))))))

--- a/annotation/string-helpers.scm
+++ b/annotation/string-helpers.scm
@@ -31,7 +31,7 @@
 
 ;;Different modes of interactions
 
-(define all-interactions '("binding" "reaction" "inhibition" "activation" "expression" "catalysis" "ptmod"))
+(define-public all-interactions '("binding" "reaction" "inhibition" "activation" "expression" "catalysis" "ptmod"))
 
 (define symmetric-interactions '("binding" "reaction"))
 

--- a/annotation/string-helpers.scm
+++ b/annotation/string-helpers.scm
@@ -75,7 +75,7 @@
 )
 
 
-(define-public (find-interaction gene chans interactions proteins
+(define-public (find-interaction gene interactions proteins
                   namespace parents regulates part-of bi-dir coding non-coding)
    ;;Find Genes that interact with the input gene. Optionally specify a filter list of the interactions
    ;;If proteins option is true do a Protein-Protein interaction
@@ -87,22 +87,20 @@
         (let (
             [proteins (find-proteins gene)]
         )
-         (for-each (lambda (res)
-            (send-message res chans)
-            (do-cross-annotation res chans proteins namespace parents regulates part-of bi-dir coding non-coding)
+         (append-map (lambda (res)
+            (do-cross-annotation res proteins namespace parents regulates part-of bi-dir coding non-coding)
          )        
             (append-map (lambda (prot) (cache-find-ggi (Set prot (List atoms)))) proteins))
         )
-        (for-each (lambda (res)
-         (send-message res chans)
-         (do-cross-annotation res chans proteins 
+        (append-map (lambda (res)
+         (do-cross-annotation res proteins 
                namespace parents regulates part-of bi-dir coding non-coding)
         ) (cache-find-ggi (Set gene (List atoms))))
       )  
    )
 )
 
-(define-public (find-output-interactions gene chans interactions proteins
+(define-public (find-output-interactions gene interactions proteins
     namespace parents regulates part-of bi-dir coding non-coding)
 
    (define (get-output-interactors intrs)
@@ -129,15 +127,14 @@
    )
 
    (let ([output-interactors (if interactions (get-output-interactors interactions) (get-output-interactors all-interactions))])
-      (for-each (lambda (res)
-         (send-message res chans)
-         (do-cross-annotation res chans proteins 
-               namespace parents regulates part-of bi-dir coding non-coding))output-interactors)
+      (append-map (lambda (res)
+         (do-cross-annotation res proteins 
+               namespace parents regulates part-of bi-dir coding non-coding)) output-interactors)
    )
 )
 
-(define (do-cross-annotation link out-chans protein
-             namespace num-parent regulates part-of bi-dir coding non-coding)
+(define (do-cross-annotation link do-protein
+             namespaces num-parents regulates part-of bi-dir coding-rna non-coding-rna)
     "
      do-cross-annotation -- add info about matched variable nodes
     `namespaces` should be a scheme list of strings (possibly an empty list),
@@ -151,38 +148,50 @@
     (let* (
         [gene-a (gadr link)]
         [gene-b (gddr link)]
-        [already-done-a ((biogrid-genes) gene-a)]
-        [already-done-b ((biogrid-genes) gene-b)]
-    )
+        [already-done-a ((intr-genes) gene-a)]
+        [already-done-b ((intr-genes) gene-b)]
+        [already-done-pair ((gene-pairs) (List gene-a gene-b))])
         
-        (if (not already-done-a)
-            (send-message (node-info gene-a) out-chans)
-        )
-
-        (if (not already-done-b)
-            (send-message (node-info gene-b) out-chans)
-        )
-        
-        
-        ;;go-cross annotation
-        (if (not (null? namespace))
-            (begin 
-               (send-message (Concept "gene-go-annotation") out-chans)
-               (send-message (find-go-term gene-a namespace num-parent regulates part-of bi-dir) out-chans)
-               (send-message (find-go-term gene-b namespace num-parent regulates part-of bi-dir) out-chans)
-               (send-message (Concept "string-annotation") out-chans)
-            )
-
-        )
-
-        (if (or coding non-coding)
-            (begin 
-               (send-message (Concept "rna-annotation") out-chans)
-               (send-message (find-rna gene-a coding non-coding protein) out-chans)
-               (send-message (Concept "string-annotation") out-chans)
-            )
-        )
-   ))
+        (cond 
+          ((and (not already-done-a) (not already-done-b))
+            (let ([go-cross-annotation
+                    (if (null? namespaces) '()
+                        (list
+                           (Concept "gene-go-annotation")
+                           (find-go-term gene-a namespaces num-parents regulates part-of bi-dir)
+                           (find-go-term gene-b namespaces num-parents regulates part-of bi-dir)
+                           (Concept "biogrid-interaction-annotation"))
+                    )]
+                    [rna-cross-annotation
+                      (if (or coding-rna non-coding-rna)
+                        (list
+                            (Concept "rna-annotation")
+                            (find-rna gene-a coding-rna non-coding-rna do-protein)
+                            (find-rna gene-b coding-rna non-coding-rna do-protein)
+                            (Concept "biogrid-interaction-annotation"))
+                          '()     
+                      )])
+                    (append (list link (node-info gene-a) (node-info gene-b))
+                      go-cross-annotation rna-cross-annotation)))
+            ((or (not already-done-a) (not already-done-b)
+              (let* ([gene-x (if already-done-a gene-b gene-a)]
+                    [go-cross-annotation
+                     (if (null? namespaces) '()
+                        (list
+                           (Concept "gene-go-annotation")
+                           (find-go-term gene-x namespaces num-parents regulates part-of bi-dir)
+                           (Concept "biogrid-interaction-annotation"))
+                     )]
+                    [rna-cross-annotation
+                     (if (or coding-rna non-coding-rna)
+                        (list
+                           (Concept "rna-annotation")
+                           (find-rna gene-x coding-rna non-coding-rna do-protein)
+                           (Concept "biogrid-interaction-annotation"))
+                        '()
+                    )])
+                    (append (list link (node-info gene-x)) go-cross-annotation rna-cross-annotation))))
+            (else (if (not already-done-pair) (list link))))))
 
 
 

--- a/annotation/string.scm
+++ b/annotation/string.scm
@@ -45,8 +45,8 @@
 
     (send-message (Concept "string-annotation") chans)
     (for-each (lambda (gene) 
-        (find-interaction (GeneNode gene) chans interaction-lst protein 
-        namespaces parents regulates part-of bi-dir coding noncoding)
-        (find-output-interactions (GeneNode gene) chans interaction-lst protein namespaces parents regulates part-of bi-dir coding noncoding)
+        (send-message (find-interaction (GeneNode gene) interaction-lst protein 
+        namespaces parents regulates part-of bi-dir coding noncoding) chans)
+        (send-message (find-output-interactions (GeneNode gene) interaction-lst protein namespaces parents regulates part-of bi-dir coding noncoding) chans)
     ) genes)
 )

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -108,24 +108,23 @@
   Call (cog-execute! QUERY), return results, delete the SetLink.
   This avoids a memory leak of SetLinks
 "
-	; Run the query
-	; (define set-link (cog-execute! QUERY))
+	Run the query
+	(define set-link (cog-execute! QUERY))
 
-	; (lock-mutex run-query-mtx)
-	; (if (cog-atom? set-link)
-	; 	; Get the query results
-	; 	(let ((results (cog-outgoing-set set-link)))
-	; 		; Delete the SetLink
-	; 		(cog-delete set-link)
-	; 		(unlock-mutex run-query-mtx)
-	; 		; Return the results.
-	; 		results)
-	; 	; Try again
-	; 	(begin
-	; 		(unlock-mutex run-query-mtx)
-	; 		(run-query QUERY))
-	; )
-  (exec-pattern "prod-atom" QUERY)
+	(lock-mutex run-query-mtx)
+	(if (cog-atom? set-link)
+		; Get the query results
+		(let ((results (cog-outgoing-set set-link)))
+			; Delete the SetLink
+			(cog-delete set-link)
+			(unlock-mutex run-query-mtx)
+			; Return the results.
+			results)
+		; Try again
+		(begin
+			(unlock-mutex run-query-mtx)
+			(run-query QUERY))
+	)
 )
 
 ; --------------------------------------------------------

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -44,8 +44,8 @@
 ;Define Parameters
 
 ; ----------------------------------------------------
-(define-public biogrid-genes (make-parameter (make-atom-set)))
-(define-public biogrid-pairs (make-parameter (make-atom-set)))
+(define-public intr-genes (make-parameter (make-atom-set)))
+(define-public gene-pairs (make-parameter (make-atom-set)))
 (define-public biogrid-reported-pathways (make-parameter (make-atom-set)))
 
 ; ----------------------------------------------------
@@ -131,8 +131,8 @@
 
 
 ;; Define the parameters needed for GGI
-(define-public biogrid-genes (make-parameter (make-atom-set)))
-(define-public biogrid-pairs (make-parameter (make-atom-set)))
+(define-public intr-genes (make-parameter (make-atom-set)))
+(define-public gene-pairs (make-parameter (make-atom-set)))
 (define-public biogrid-reported-pathways (make-parameter (make-atom-set)))
 (define-public ws (make-parameter '()))
 

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -108,7 +108,7 @@
   Call (cog-execute! QUERY), return results, delete the SetLink.
   This avoids a memory leak of SetLinks
 "
-	Run the query
+
 	(define set-link (cog-execute! QUERY))
 
 	(lock-mutex run-query-mtx)
@@ -253,18 +253,12 @@
                       (EvaluationLink (PredicateNode "has_entrez_id")
                       (ListLink
                           gene
-                          (VariableNode "$a"))))
-                    )
-                  )
-          )
-    )
+                          (VariableNode "$a"))))))))
     (match (string-split entrez #\:)
       ((single) single)
       ((first second . rest) second))
       
-  )
-      
-)
+  ))
 
 (define (do-find-name GO-ATOM)
 "

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -309,8 +309,7 @@
       
       (if (> (length res) 5) 
         (take res 5)
-        res
-  )))
+        res)))
 
 ; --------------------------------------------------------
 
@@ -320,8 +319,7 @@
             (Evaluation
                (Predicate "has_current_symbol")
                (ListLink (Gene gene) (Variable "$g")))
-            (VariableNode "$g"))))
-)
+            (VariableNode "$g")))))
 
 (define-public (build-pubmed-url nodename)
  (string-append "https://www.ncbi.nlm.nih.gov/pubmed/?term=" (cadr (string-split nodename #\:)))

--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -25,7 +25,6 @@
 	#:use-module (opencog exec)
 	#:use-module (opencog bioscience)
 	#:use-module (annotation graph)
-  #:use-module (opencog grpc)
   #:use-module (fibers channels)
 	#:use-module (ice-9 optargs)
 	#:use-module (rnrs exceptions)

--- a/annotation/writer.scm
+++ b/annotation/writer.scm
@@ -28,17 +28,15 @@
 
 (install-suspendable-ports!)
 
-(define-public (output-to-file chan port)
+(define-public (output-to-file proc port)
     (let loop (
-      (msg (get-message chan))
+      (msg (proc))
    )
     (if (equal? msg 'eof)
       (close-port port)   
       (begin 
          (write msg port)
-         (loop (get-message chan))
+         (loop (proc))
       )
     )
-  )
-
-)
+))

--- a/tests/main-tests.scm
+++ b/tests/main-tests.scm
@@ -20,17 +20,17 @@
 (primitive-load "tests/sample_dataset.scm")
 (primitive-load "annotation/pln_rule.scm")
 
-(define req "[{\"function_name\": \"gene-pathway-annotation\", \"filters\": [{\"filter\": \"pathway\", \"value\": \"smpdb reactome\"},{\"filter\": \"include_prot\", \"value\": \"True\"}, {\"filter\": \"include_sm\", \"value\": \"False\"},{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"}, {\"filter\": \"biogrid\", \"value\": \"0\"}]}, {\"function_name\": \"gene-go-annotation\", \"filters\": [{\"filter\": \"namespace\", \"value\": \"biological_process cellular_component molecular_function\"}, {\"filter\": \"parents\", \"value\": \"0\"}, {\"filter\": \"protein\", \"value\": \"True\"}]}, {\"function_name\": \"include-rna\", \"filters\": [{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"},{\"filter\": \"protein\", \"value\": \"1\"}]},{\"function_name\": \"biogrid-interaction-annotation\", \"filters\": [{\"filter\": \"interaction\", \"value\": \"Proteins\"}]}]")
+(define req "[{\"functionName\": \"gene-pathway-annotation\", \"filters\": [{\"filter\": \"pathway\", \"value\": \"smpdb reactome\"},{\"filter\": \"include_prot\", \"value\": \"True\"}, {\"filter\": \"include_sm\", \"value\": \"False\"},{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"}, {\"filter\": \"biogrid\", \"value\": \"0\"}]}, {\"functionName\": \"gene-go-annotation\", \"filters\": [{\"filter\": \"namespace\", \"value\": \"biological_process cellular_component molecular_function\"}, {\"filter\": \"parents\", \"value\": \"0\"}, {\"filter\": \"protein\", \"value\": \"True\"}]}, {\"functionName\": \"include-rna\", \"filters\": [{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"},{\"filter\": \"protein\", \"value\": \"1\"}]},{\"functionName\": \"biogrid-interaction-annotation\", \"filters\": [{\"filter\": \"interaction\", \"value\": \"Proteins\"}]}]")
 
-(define invalid-req "[{\"function_name\": \"unknown-function\", \"filters\": [{\"filter\": \"pathway\", \"value\": \"smpdb reactome\"},{\"filter\": \"include_prot\", \"value\": \"True\"}, {\"filter\": \"include_sm\", \"value\": \"False\"},{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"}, {\"filter\": \"biogrid\", \"value\": \"0\"}]}]")
+(define invalid-req "[{\"functionName\": \"unknown-function\", \"filters\": [{\"filter\": \"pathway\", \"value\": \"smpdb reactome\"},{\"filter\": \"include_prot\", \"value\": \"True\"}, {\"filter\": \"include_sm\", \"value\": \"False\"},{\"filter\": \"coding\", \"value\": \"True\"},{\"filter\": \"noncoding\", \"value\": \"True\"}, {\"filter\": \"biogrid\", \"value\": \"0\"}]}]")
 
-(test-equal "parse-request" 5 (length (parse-request (list "IGF1") "Dfaer" req)))
+(test-equal "parse-request" 4 (length (parse-request req)))
 
 ;;This should only return a single list which contains the `gene-info` function. 
 ;;This is because the function name `unknown-function` is not in the list `annotation-functions`
-(test-equal "validate-functions" 1 (length (parse-request (list "IGF1") "Dfaer" invalid-req)))
+(test-equal "validate-functions" 1 (length (parse-request invalid-req)))
 
-(test-equal "annotate-genes" #t ((lambda () (annotate-genes (list "IGF1") "Dfaer" req) (file-exists? "/tmp/result/Dfaer/Dfaer.json"))))
+(test-equal "annotate-genes" #t ((lambda () (annotate-genes (list "IGF1") "Dfaer" req) (file-exists? (get-file-path "Dfaer" "Dfaer" ".json")))))
 
 (test-equal "find-genes" 1 (length (vector->list (json-string->scm (find-genes (list "IGF" "IGF1"))))))
 

--- a/tests/parser-tests.scm
+++ b/tests/parser-tests.scm
@@ -7,7 +7,8 @@
     #:use-module (annotation gene-pathway)
     #:use-module (annotation graph)
     #:use-module (annotation biogrid)
-    #:use-module (annotation parser))
+    #:use-module (annotation parser)
+    #:use-module (json))
 
 (test-begin "parser")
 
@@ -64,9 +65,20 @@
    (lambda () (set! i (+ i 1)) (if (>= i n) 'eof (list-ref res (- i 1))))
 ))
 
-(test-assert "node-count" (= (vector-length (cdar (atomese-parser proc))) 2))
+(define out (open-output-file "test.json"))
+(atomese-parser proc out)
+(define input (open-input-file "test.json"))
 
-(define i 0) ;; reset the list index
-(test-assert "edge-count" (= (vector-length (cdadr (atomese-parser proc))) 1))
+(define json (json->scm input))
+
+
+(test-assert "node-count" (= 2 (vector-length (assoc-ref json "nodes"))))
+
+(test-assert "edge-count" (= 1 (vector-length (assoc-ref json "edges"))))
+
+
+(close-port input)
+;;remove the file
+(system "rm test.json")
 
 (test-end "parser")

--- a/tests/parser-tests.scm
+++ b/tests/parser-tests.scm
@@ -11,7 +11,7 @@
 
 (test-begin "parser")
 
-(define res  (ListLink
+(define res  (list
          (EvaluationLink
             (PredicateNode "has_pubmedID")
             (ListLink
@@ -58,11 +58,15 @@
             )
          )
 ))
+(define n (length res))
+(define i 0)
+(define proc (let ()
+   (lambda () (set! i (+ i 1)) (if (>= i n) 'eof (list-ref res (- i 1))))
+))
 
-(test-assert "atomese-parser"  (graph? (atomese-parser res)))
+(test-assert "node-count" (= (vector-length (cdar (atomese-parser proc))) 2))
 
-(test-assert "node-count" (= (length (graph-nodes (atomese-parser res))) 2))
-
-(test-assert "edge-count" (= (length (graph-edges (atomese-parser res))) 1))
+(define i 0) ;; reset the list index
+(test-assert "edge-count" (= (vector-length (cdadr (atomese-parser proc))) 1))
 
 (test-end "parser")

--- a/tests/string-tests.scm
+++ b/tests/string-tests.scm
@@ -3,7 +3,7 @@
     #:use-module (opencog)
     #:use-module (opencog exec)
     #:use-module (opencog bioscience)
-    #:use-module (annotation functions)
+    #:use-module (annotation string-helpers)
     #:use-module (annotation util)
 )
 
@@ -16,16 +16,13 @@
 ;;Fake expression to find ppi
 (define expr-link (Evaluation 
                     (Predicate "expresses")
-                    (List (Gene "ARF5") (MoleculeNode "Uniprot:P84085"))
-            ))
+                    (List (Gene "ARF5") (MoleculeNode "Uniprot:P84085"))))
 
-(test-equal "find-ggi" 19 (length (find-ggi (Gene "ARF5"))))
+(define atoms (map (lambda (i) (Concept i)) all-interactions))
 
-(test-equal "find-ggi-filtered" 9 (length (find-ggi (Gene "ARF5") '("reaction"))))
+(test-equal "find-ggi" 19 (length (do-find-ggi (Set (Gene "ARF5") (List atoms)))))
 
-(test-equal "find-ppi" 19 (length (find-ppi (Gene "ARF5"))))
-
-(test-equal "find-ppi-filtered" 9 (length (find-ppi (Gene "ARF5") '("reaction"))))
+(test-equal "find-ggi-filtered" 9 (length (do-find-ggi (Set (Gene "ARF5") (List (Concept "reaction"))))))
 
 (clear)
 


### PR DESCRIPTION
This PR moves out the fiber channels argument from the pattern matcher search functions to the outer annotation functions to make easy to test those functions. Also makes the parser testable and fixes the parser tests