### PR TITLE
Return a GeneNode instead of ConceptNode for uniprot/coding-rna names

### DIFF
--- a/annotation/util.scm
+++ b/annotation/util.scm
@@ -175,7 +175,7 @@
            (Evaluation (Predicate predicate)
               (List (Variable "$a") node))))])
 
-        (if (null? name) (Concept "N/A") (car name)))
+        (if (null? name) (GeneNode "N/A") (car name)))
 )
 
 (define find-prot/enst-name


### PR DESCRIPTION
Instead of returning (Concept "N/A") when there is no coding gene is not found, the do-find-prot/enst-name function should return (GeneNode "N/A") for the parser to work